### PR TITLE
Fix bundled binary lookup for ffmpeg/ffprobe/yt-dlp on macOS/Linux

### DIFF
--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -1,5 +1,12 @@
 use std::path::{Path, PathBuf};
 
+/// Returns a list of candidate paths where the given binary may be found.
+///
+/// This helper handles platform-specific path resolution logic, including
+/// searching in locations relevant to macOS, Linux, and Windows, as well as
+/// considering environment variables and build-time directories. This is
+/// necessary because binary locations can vary depending on how the application
+/// is packaged or run.
 fn binary_candidates(bin: &str) -> Vec<PathBuf> {
     let mut paths = vec![Path::new("binaries").join(bin)];
 

--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Returns a list of candidate paths where the given binary may be found.
 ///
@@ -53,6 +54,13 @@ pub fn resolve_binary(name: &str) -> Option<String> {
         if path.exists() {
             let canonical = path.canonicalize().unwrap_or(path);
             return Some(canonical.to_string_lossy().to_string());
+        }
+    }
+
+    let base = bin.strip_suffix(".exe").unwrap_or(&bin);
+    for name in [bin.as_str(), base] {
+        if Command::new(name).arg("-version").output().is_ok() {
+            return Some(name.to_string());
         }
     }
 

--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -1,0 +1,53 @@
+use std::path::{Path, PathBuf};
+
+fn binary_candidates(bin: &str) -> Vec<PathBuf> {
+    let mut paths = vec![Path::new("binaries").join(bin)];
+
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            paths.push(dir.join("binaries").join(bin));
+
+            #[cfg(target_os = "macos")]
+            {
+                paths.push(dir.join("../Resources/binaries").join(bin));
+            }
+
+            #[cfg(target_os = "linux")]
+            {
+                paths.push(dir.join(format!("../lib/{}/binaries", env!("CARGO_PKG_NAME"))).join(bin));
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(appdir) = std::env::var("APPDIR") {
+            paths.push(Path::new(&appdir).join(format!("usr/lib/{}/binaries", env!("CARGO_PKG_NAME"))).join(bin));
+        }
+
+        paths.push(Path::new("/usr/lib").join(env!("CARGO_PKG_NAME")).join("binaries").join(bin));
+    }
+
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        paths.push(Path::new(&manifest_dir).join("binaries").join(bin));
+    }
+
+    paths
+}
+
+pub fn resolve_binary(name: &str) -> Option<String> {
+    let bin = if cfg!(target_os = "windows") {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    };
+
+    for path in binary_candidates(&bin) {
+        if path.exists() {
+            let canonical = path.canonicalize().unwrap_or(path);
+            return Some(canonical.to_string_lossy().to_string());
+        }
+    }
+
+    None
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,17 +54,22 @@ async fn download_from_youtube(
     let yt_dlp_path = binaries::resolve_binary("yt-dlp")
         .ok_or_else(|| "yt-dlp binary not found".to_string())?;
 
-    let binaries_dir = Path::new(&yt_dlp_path)
+    let ffmpeg_path = binaries::resolve_binary("ffmpeg")
+        .ok_or_else(|| "ffmpeg binary not found".to_string())?;
+
+    let ffmpeg_dir = Path::new(&ffmpeg_path)
         .parent()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|| "binaries".to_string());
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_string_lossy().to_string());
 
     // Configuration selon le type (audio ou vidéo)
     let mut args = vec!["--force-ipv4"];
 
     // Ajouter le chemin vers le dossier contenant ffmpeg et ffprobe
-    args.push("--ffmpeg-location");
-    args.push(&binaries_dir);
+    if let Some(dir) = ffmpeg_dir {
+        args.push("--ffmpeg-location");
+        args.push(&dir);
+    }
 
     // Pattern de sortie avec le titre de la vidéo et le nom de la chaîne
     let output_pattern = format!("{}/%(title)s (%(uploader)s).%(ext)s", download_path);


### PR DESCRIPTION
- Add a shared binaries::resolve_binary helper that searches exe dir, Resources/, AppImage /usr/lib/.../binaries, APPDIR, and manifest dir before falling back to PATH.

- Update yt-dlp, ffprobe, ffmpeg callers in Tauri commands and exporter to use the shared resolver so packaged bundles find the shipped binaries on macOS/Linux.