### PR TITLE
probleme open directory pour windows

### DIFF
--- a/src/lib/classes/Asset.svelte.ts
+++ b/src/lib/classes/Asset.svelte.ts
@@ -81,10 +81,10 @@ export class Asset extends SerializableBase {
 			// Demande confirmation à l'utilisateur
 			const confirm = await ModalManager.confirmModal(
 				'Would you like to set the project dimensions to match this video? (' +
-					assetDimensions.width +
-					'x' +
-					assetDimensions.height +
-					')',
+				assetDimensions.width +
+				'x' +
+				assetDimensions.height +
+				')',
 				true
 			);
 
@@ -144,7 +144,14 @@ export class Asset extends SerializableBase {
 	}
 
 	async openParentDirectory() {
-		const parentDir = this.getParentDirectory();
+		let parentDir = this.getParentDirectory();
+		const userAgent = navigator?.userAgent?.toLowerCase() ?? '';
+		// Windows Explorer handles paths with forward slashes incorrectly when opening a directory via the opener plugin.
+		// It often defaults to the Documents folder or times out.
+		// We force backslashes for Windows to ensure the correct directory opens immediately.
+		if (userAgent.includes('win')) {
+			parentDir = parentDir.replace(/\//g, '\\');
+		}
 		await openPath(parentDir);
 	}
 


### PR DESCRIPTION
quand tu vas dans assets et tu met open directory . ca ouvrait le fichier Documents et ca mettait plusieurs secondes genre 7 a 10 a ouvrir le bon folder ou se trouve l'asset . la j'ai fixed pour windows ca ouvre direct le bon folder sans lagging .