### PR TITLE
fix menu non closing before changing tab

### DIFF
--- a/src/lib/components/home/ProjectDetailCard.svelte
+++ b/src/lib/components/home/ProjectDetailCard.svelte
@@ -10,6 +10,7 @@
 	import { slide } from 'svelte/transition';
 	import MigrationService from '$lib/services/MigrationService';
 	import { discordService } from '$lib/services/DiscordService';
+	import { onDestroy } from 'svelte';
 
 	let contextMenu: ContextMenu | undefined = $state(undefined); // Initialize context menu state
 
@@ -32,10 +33,8 @@
 		}
 	}
 
-	$effect(() => {
-		return () => {
-			currentMenu.set(null);
-		};
+	onDestroy(() => {
+		currentMenu.set(null);
 	});
 
 	async function openProjectButtonClick() {

--- a/src/lib/components/home/ProjectDetailCard.svelte
+++ b/src/lib/components/home/ProjectDetailCard.svelte
@@ -2,6 +2,7 @@
 	import { ProjectDetail } from '$lib/classes';
 	import { ProjectService } from '$lib/services/ProjectService';
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
+	import { currentMenu } from 'svelte-contextmenu/stores';
 	import { globalState } from '$lib/runes/main.svelte';
 	import EditableText from '../misc/EditableText.svelte';
 	import ModalManager from '../modals/ModalManager';
@@ -27,9 +28,15 @@
 		) {
 			await ProjectService.delete(projectDetail.id); // Supprime le projet
 		} else {
-			contextMenu!.close();
+			currentMenu.set(null);
 		}
 	}
+
+	$effect(() => {
+		return () => {
+			currentMenu.set(null);
+		};
+	});
 
 	async function openProjectButtonClick() {
 		// Ouvre le projet

--- a/src/lib/components/projectEditor/Navigator.svelte
+++ b/src/lib/components/projectEditor/Navigator.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { ProjectEditorTabs } from '$lib/classes';
 	import { globalState } from '$lib/runes/main.svelte';
-	import { currentMenu } from 'svelte-contextmenu/stores';
 
 	let tabs = $state([
 		{ name: 'Video editor', icon: 'edit', value: ProjectEditorTabs.VideoEditor },
@@ -12,7 +11,6 @@
 	]);
 
 	function setActiveTab(tabValue: ProjectEditorTabs) {
-		globalState.closeAllMenus();
 		globalState.getStylesState.clearSelection();
 		globalState.currentProject!.projectEditorState.currentTab = tabValue;
 	}

--- a/src/lib/components/projectEditor/Navigator.svelte
+++ b/src/lib/components/projectEditor/Navigator.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ProjectEditorTabs } from '$lib/classes';
 	import { globalState } from '$lib/runes/main.svelte';
+	import { currentMenu } from 'svelte-contextmenu/stores';
 
 	let tabs = $state([
 		{ name: 'Video editor', icon: 'edit', value: ProjectEditorTabs.VideoEditor },
@@ -11,6 +12,7 @@
 	]);
 
 	function setActiveTab(tabValue: ProjectEditorTabs) {
+		globalState.closeAllMenus();
 		globalState.getStylesState.clearSelection();
 		globalState.currentProject!.projectEditorState.currentTab = tabValue;
 	}

--- a/src/lib/components/projectEditor/ProjectEditor.svelte
+++ b/src/lib/components/projectEditor/ProjectEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import { getCurrentWindow } from '@tauri-apps/api/window';
 	import VideoPreview from './videoPreview/VideoPreview.svelte';
 	import Timeline from './timeline/Timeline.svelte';
@@ -36,10 +36,6 @@
 			clearInterval(saveInterval);
 			window.removeEventListener('mousedown', handleGlobalClick, true);
 		};
-	});
-
-	onDestroy(() => {
-		// Le cleanup est géré par onMount return
 	});
 </script>
 

--- a/src/lib/components/projectEditor/ProjectEditor.svelte
+++ b/src/lib/components/projectEditor/ProjectEditor.svelte
@@ -21,10 +21,25 @@
 		saveInterval = setInterval(() => {
 			globalState.currentProject?.save();
 		}, 5000);
+
+		// Fermer les menus contextuels lors d'un clic en dehors
+		const handleGlobalClick = (e: MouseEvent) => {
+			const portal = document.getElementById('context-menu-portal');
+			if (portal && portal.contains(e.target as Node)) {
+				return;
+			}
+			globalState.closeAllMenus();
+		};
+		window.addEventListener('mousedown', handleGlobalClick, true);
+
+		return () => {
+			clearInterval(saveInterval);
+			window.removeEventListener('mousedown', handleGlobalClick, true);
+		};
 	});
 
 	onDestroy(() => {
-		clearInterval(saveInterval);
+		// Le cleanup est géré par onMount return
 	});
 </script>
 

--- a/src/lib/components/projectEditor/timeline/track/Clip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/Clip.svelte
@@ -6,6 +6,7 @@
 	import { fade, slide } from 'svelte/transition';
 	import WaveSurfer from 'wavesurfer.js';
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
+	import { currentMenu } from 'svelte-contextmenu/stores';
 
 	let {
 		clip = $bindable(),
@@ -14,6 +15,12 @@
 		clip: Clip;
 		track: Track;
 	} = $props();
+
+	$effect(() => {
+		return () => {
+			currentMenu.set(null);
+		};
+	});
 
 	let contextMenu: ContextMenu | undefined = $state(undefined); // Initialize context menu state
 

--- a/src/lib/components/projectEditor/timeline/track/Clip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/Clip.svelte
@@ -2,7 +2,7 @@
 	import { AssetType, TrackType, type AssetClip, type Clip, type Track } from '$lib/classes';
 	import { globalState } from '$lib/runes/main.svelte';
 	import { convertFileSrc } from '@tauri-apps/api/core';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
 	import WaveSurfer from 'wavesurfer.js';
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
@@ -16,10 +16,8 @@
 		track: Track;
 	} = $props();
 
-	$effect(() => {
-		return () => {
-			currentMenu.set(null);
-		};
+	onDestroy(() => {
+		currentMenu.set(null);
 	});
 
 	let contextMenu: ContextMenu | undefined = $state(undefined); // Initialize context menu state

--- a/src/lib/components/projectEditor/timeline/track/CustomClip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/CustomClip.svelte
@@ -3,6 +3,7 @@
 	import { globalState } from '$lib/runes/main.svelte';
 	import { fade, slide } from 'svelte/transition';
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
+	import { currentMenu } from 'svelte-contextmenu/stores';
 	import type { CustomClip, CustomImageClip } from '$lib/classes/Clip.svelte';
 
 	let {
@@ -12,6 +13,12 @@
 		clip: CustomClip;
 		track: Track;
 	} = $props();
+
+	$effect(() => {
+		return () => {
+			currentMenu.set(null);
+		};
+	});
 
 	let positionLeft = $derived(() => {
 		// Si le custom text est visible sur toute la vidéo, on force le début à 0.

--- a/src/lib/components/projectEditor/timeline/track/CustomClip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/CustomClip.svelte
@@ -5,6 +5,7 @@
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
 	import { currentMenu } from 'svelte-contextmenu/stores';
 	import type { CustomClip, CustomImageClip } from '$lib/classes/Clip.svelte';
+	import { onDestroy } from 'svelte';
 
 	let {
 		clip = $bindable(),
@@ -14,10 +15,8 @@
 		track: Track;
 	} = $props();
 
-	$effect(() => {
-		return () => {
-			currentMenu.set(null);
-		};
+	onDestroy(() => {
+		currentMenu.set(null);
 	});
 
 	let positionLeft = $derived(() => {

--- a/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
@@ -13,6 +13,7 @@
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
 	import { currentMenu } from 'svelte-contextmenu/stores';
 	import type { SubtitleTrack } from '$lib/classes/Track.svelte';
+	import { onDestroy } from 'svelte';
 
 	let {
 		clip = $bindable(),
@@ -156,10 +157,8 @@
 		globalState.getSubtitlesEditorState.editSubtitle = clip;
 	}
 
-	$effect(() => {
-		return () => {
-			currentMenu.set(null);
-		};
+	onDestroy(() => {
+		currentMenu.set(null);
 	});
 </script>
 

--- a/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
@@ -11,6 +11,7 @@
 	import { globalState } from '$lib/runes/main.svelte';
 	import { fade, slide } from 'svelte/transition';
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
+	import { currentMenu } from 'svelte-contextmenu/stores';
 	import type { SubtitleTrack } from '$lib/classes/Track.svelte';
 
 	let {
@@ -154,6 +155,12 @@
 		}
 		globalState.getSubtitlesEditorState.editSubtitle = clip;
 	}
+
+	$effect(() => {
+		return () => {
+			currentMenu.set(null);
+		};
+	});
 </script>
 
 <div

--- a/src/lib/runes/main.svelte.ts
+++ b/src/lib/runes/main.svelte.ts
@@ -7,6 +7,7 @@ import {
 	type PredefinedSubtitleClip,
 	ProjectTranslation
 } from '$lib/classes';
+import { currentMenu } from 'svelte-contextmenu/stores';
 import type Exportation from '$lib/classes/Exportation.svelte';
 import type Settings from '$lib/classes/Settings.svelte';
 import { Status } from '$lib/classes/Status';
@@ -136,6 +137,18 @@ class GlobalState {
 			if (edition) return edition;
 		}
 		return null;
+	}
+
+	closeAllMenus() {
+		currentMenu.set(null);
+		// Force close any existing portal elements just in case reactivity fails
+		if (typeof document !== 'undefined') {
+			const portal = document.getElementById('context-menu-portal');
+			if (portal) {
+				const menus = portal.querySelectorAll('.context-menu');
+				menus.forEach((m) => m.classList.remove('show'));
+			}
+		}
 	}
 }
 

--- a/src/lib/runes/main.svelte.ts
+++ b/src/lib/runes/main.svelte.ts
@@ -141,14 +141,6 @@ class GlobalState {
 
 	closeAllMenus() {
 		currentMenu.set(null);
-		// Force close any existing portal elements just in case reactivity fails
-		if (typeof document !== 'undefined') {
-			const portal = document.getElementById('context-menu-portal');
-			if (portal) {
-				const menus = portal.querySelectorAll('.context-menu');
-				menus.forEach((m) => m.classList.remove('show'));
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
quand on faisait click droit menu , qu'il apparait et que je change de tab sans clicker dessus il reste ouver indefinimment et on ne pouvait plus le refermer...

### Fix: Nettoyage et fermeture des menus contextuels
Cette Pull Request corrige les problèmes de menus contextuels qui restaient affichés de manière persistante lors de la navigation ou du clic extérieur.

**Changements principaux**
Fermeture globale : Ajout d'une méthode 
closeAllMenus()
 dans 
GlobalState
 pour réinitialiser le store et forcer la disparition des éléments DOM.
**Navigation fluide :** Les menus se ferment désormais automatiquement lors du changement d'onglet dans l'éditeur.
Clic extérieur : Ajout d'un listener global sur le ProjectEditor pour détecter les clics en dehors des menus.
Sécurité cycle de vie : Ajout de cleanups $effect sur les composants de clips (
_SubtitleClip_
, 
_Clip_
, 
_CustomClip_
) et les cartes de projet.