### PR TITLE
Shared timeline for qurancaption

### DIFF
--- a/src/lib/components/projectEditor/ProjectEditor.svelte
+++ b/src/lib/components/projectEditor/ProjectEditor.svelte
@@ -6,13 +6,18 @@
 	import Navigator from './Navigator.svelte';
 	import { globalState } from '$lib/runes/main.svelte';
 	import { ProjectEditorTabs } from '$lib/classes';
-	import VideoEditor from './tabs/videoEditor/VideoEditor.svelte';
-	import SubtitlesEditor from './tabs/subtitlesEditor/SubtitlesEditor.svelte';
 	import toast from 'svelte-5-french-toast';
+	
+	// Specific Tab Components
+	import AssetsManager from './tabs/videoEditor/assetsManager/AssetsManager.svelte';
+	import SubtitlesEditorSettings from './tabs/subtitlesEditor/SubtitlesEditorSettings.svelte';
+	import SubtitlesWorkspace from './tabs/subtitlesEditor/SubtitlesWorkspace.svelte';
+	import SubtitlesList from './tabs/subtitlesEditor/SubtitlesList.svelte';
+	import StyleEditorSettings from './tabs/styleEditor/StyleEditorSettings.svelte';
+	import ExportSettings from './tabs/export/ExportSettings.svelte';
 	import TranslationsEditor from './tabs/translationsEditor/TranslationsEditor.svelte';
-	import StyleEditor from './tabs/styleEditor/StyleEditor.svelte';
-	import QPCFontProvider from '$lib/services/FontProvider';
-	import Export from './tabs/export/Export.svelte';
+	
+	import DiviseurRedimensionnable from './tabs/DiviseurRedimensionnable.svelte';
 
 	let saveInterval: any;
 
@@ -42,15 +47,97 @@
 <div class="flex flex-col h-full bg-secondary min-h-0 overflow-hidden">
 	<Navigator />
 
-	{#if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.VideoEditor}
-		<VideoEditor />
-	{:else if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.SubtitlesEditor}
-		<SubtitlesEditor />
-	{:else if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Translations}
+	<!-- Translations Editor (Rendered but hidden when not active to preserve state) -->
+	<div 
+		class="h-full min-h-0" 
+		class:hidden={globalState.currentProject!.projectEditorState.currentTab !== ProjectEditorTabs.Translations}
+	>
 		<TranslationsEditor />
-	{:else if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Style}
-		<StyleEditor />
-	{:else if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Export}
-		<Export />
-	{/if}
+	</div>
+
+	<!-- Shared Layout for Video, Subtitles, Style, Export (Timeline Shared) -->
+	<div 
+		class="flex-grow w-full max-w-full flex overflow-hidden h-full min-h-0"
+		class:hidden={globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Translations}
+	>
+		<!-- Left Panel -->
+		<section
+			class="flex-shrink-0 divide-y-2 divide-color max-h-full overflow-hidden flex flex-col transition-all duration-200"
+			class:w-[300px]={globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.VideoEditor || globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Style}
+			class:w-[225px]={globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.SubtitlesEditor}
+			class:2xl:w-[300px]={globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.SubtitlesEditor}
+			class:2xl:w-[350px]={globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Style}
+			class:w-[350px]={globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Export}
+			class:2xl:w-[450px]={globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Export}
+		>
+			<!-- Helper class for Style tab width since we can't have duplicate keys cleanly in class directive with conflict -->
+			<!-- Actually, Tailwind classes just append. We need to ensure we don't have conflicting width classes applied simultaneously.
+				 Logic:
+				 Video: w-[300px]
+				 Subtitles: w-[225px] 2xl:w-[300px]
+				 Style: w-[300px] 2xl:w-[350px]
+				 Export: w-[350px] 2xl:w-[450px]
+			-->
+			
+			{#if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.VideoEditor}
+				<AssetsManager />
+			{:else if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.SubtitlesEditor}
+				<SubtitlesEditorSettings />
+			{:else if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Style}
+				<StyleEditorSettings />
+			{:else if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.Export}
+				<ExportSettings />
+			{/if}
+		</section>
+
+		<!-- Center Panel -->
+		<section class="flex-1 min-w-0 flex flex-row max-h-full min-h-0">
+			<section class="w-full min-w-0 flex flex-col min-h-0">
+				<!-- Upper Workspace (Video Preview or Subtitles Workspace) -->
+				<!-- Note: Depending on tab, we show VideoPreview HERE or in Right Panel.
+					 Use display:none to keep instances if necessary, but SubtitlesWorkspace is distinct from VideoPreview.
+					 Ideally we want ONE VideoPreview instance.
+					 But Subtitles tab puts VideoPreview in the Right sidebar.
+					 Moving a DOM element (VideoPreview) between parents without remount involves complexity (reparenting script).
+					 For now, we utilize the conditional rendering. Switching to Subtitles WILL remount VIDEO PREVIEW.
+					 BUT Timeline stays. This is the main gain.
+				-->
+				{#if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.SubtitlesEditor}
+					<SubtitlesWorkspace />
+				{:else}
+					<VideoPreview showControls={true} />
+				{/if}
+
+				<DiviseurRedimensionnable />
+
+				<!-- Shared Timeline (Persists across these tabs) -->
+				<Timeline />
+			</section>
+		</section>
+
+		<!-- Right Panel (Only for Subtitles) -->
+		{#if globalState.currentProject!.projectEditorState.currentTab === ProjectEditorTabs.SubtitlesEditor}
+			<section
+				class="w-[200px] 2xl:w-[300px] flex-shrink-0 divide-y-2 divide-color max-h-full overflow-hidden flex flex-col border border-color rounded-lg border-l-0 relative"
+			>
+				<VideoPreview showControls={false} />
+
+				<!-- Play/Pause Overlay for Subtitles Tab -->
+				<button
+					class="flex items-center justify-center w-8 h-8 text-[var(--text-on-hover)] bg-accent/20 hover:bg-accent rounded-full transition-colors cursor-pointer duration-200 absolute top-2 right-2 z-20 border-2 border-color"
+					onclick={() => {
+						globalState.getVideoPreviewState.togglePlayPause();
+					}}
+				>
+					<span class="material-icons text-xl pt-0.25">
+						{globalState.getVideoPreviewState.isPlaying ? 'pause' : 'play_arrow'}
+					</span>
+				</button>
+
+				<div class="flex-1 min-h-0 overflow-hidden z-15">
+					<SubtitlesList />
+				</div>
+			</section>
+		{/if}
+	</div>
 </div>

--- a/src/lib/components/projectEditor/tabs/DiviseurRedimensionnable.svelte
+++ b/src/lib/components/projectEditor/tabs/DiviseurRedimensionnable.svelte
@@ -5,10 +5,13 @@
 
 	let isDragging = $state(false);
 	let containerRef: HTMLElement | null = $state(null);
+	let diviseurElement: HTMLElement;
 
 	onMount(() => {
 		// containerRef = parent de ce composant
-		containerRef = document.querySelector('.diviseur')?.parentNode as HTMLElement;
+		if (diviseurElement) {
+			containerRef = diviseurElement.parentNode as HTMLElement;
+		}
 	});
 
 	function startResize(e: MouseEvent) {
@@ -39,6 +42,7 @@
 
 <!-- Diviseur redimensionnable -->
 <div
+	bind:this={diviseurElement}
 	class="h-0.75 bg-secondary cursor-row-resize flex-shrink-0 diviseur {isDragging
 		? 'bg-blue-500'
 		: ''}"

--- a/src/lib/components/projectEditor/tabs/subtitlesEditor/WordsSelector.svelte
+++ b/src/lib/components/projectEditor/tabs/subtitlesEditor/WordsSelector.svelte
@@ -70,149 +70,179 @@
 				subtitlesEditorState().selectedVerse
 			)
 	);
-	onMount(() => {
-		// Set up les shortcuts pour sélectionner les mots
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_NEXT_WORD,
-			onKeyDown: selectNextWord
-		});
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_PREVIOUS_WORD,
-			onKeyDown: selectPreviousWord
-		});
+	// Identifiants des raccourcis enregistrés
+	// No longer used for manual storage, but kept if needed for other logic (none here)
+	// We can use a local variable inside effect
 
-		// Set up les shortcuts divers
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.RESET_START_CURSOR,
-			onKeyDown: () => {
-				subtitlesEditorState().startWordIndex = subtitlesEditorState().endWordIndex;
-			}
-		});
+	$effect(() => {
+		if (!globalState.settings) return;
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_ALL_WORDS,
-			onKeyDown: async () => {
-				subtitlesEditorState().startWordIndex = 0;
-				subtitlesEditorState().endWordIndex = (await selectedVerse())!.words.length - 1;
-			}
-		});
+		const ids = {
+			SELECT_NEXT_WORD: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.SELECT_NEXT_WORD,
+				onKeyDown: selectNextWord
+			}),
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.SET_END_TO_LAST,
-			onKeyDown: async () => {
-				subtitlesEditorState().endWordIndex = (await selectedVerse())!.getNextPunctuationMarkIndex(
-					subtitlesEditorState().endWordIndex
-				);
-			}
-		});
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.SET_END_TO_PREVIOUS,
-			onKeyDown: async () => {
-				const verse = await selectedVerse();
-				if (!verse) return; // Sans verset actif, on ne peut pas chercher de ponctuation
+			SELECT_PREVIOUS_WORD: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.SELECT_PREVIOUS_WORD,
+				onKeyDown: selectPreviousWord
+			}),
 
-				const previousEndIndex = verse.getPreviousPunctuationMarkIndex(
-					subtitlesEditorState().endWordIndex
-				);
-
-				if (previousEndIndex === subtitlesEditorState().endWordIndex) {
-					return; // Déjà sur un signe d'arrêt, on ne bouge pas
-				}
-
-				subtitlesEditorState().endWordIndex = previousEndIndex;
-				if (subtitlesEditorState().startWordIndex > subtitlesEditorState().endWordIndex) {
-					// Garde une sélection valide en ramenant le début sur la fin
+			RESET_START_CURSOR: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.RESET_START_CURSOR,
+				onKeyDown: () => {
 					subtitlesEditorState().startWordIndex = subtitlesEditorState().endWordIndex;
 				}
-			}
-		});
+			}),
 
-		// Set up les shortcuts d'action
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_SUBTITLE,
-			onKeyDown: addSubtitle
-		});
+			SELECT_ALL_WORDS: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.SELECT_ALL_WORDS,
+				onKeyDown: async () => {
+					subtitlesEditorState().startWordIndex = 0;
+					subtitlesEditorState().endWordIndex = (await selectedVerse())!.words.length - 1;
+				}
+			}),
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.REMOVE_LAST_SUBTITLE,
-			onKeyDown: removeLastSubtitle
-		});
+			SET_END_TO_LAST: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.SET_END_TO_LAST,
+				onKeyDown: async () => {
+					subtitlesEditorState().endWordIndex = (await selectedVerse())!.getNextPunctuationMarkIndex(
+						subtitlesEditorState().endWordIndex
+					);
+				}
+			}),
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.EDIT_LAST_SUBTITLE,
-			onKeyDown: editCurrentOrLastSubtitle
-		});
+			SET_END_TO_PREVIOUS: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.SET_END_TO_PREVIOUS,
+				onKeyDown: async () => {
+					const verse = await selectedVerse();
+					if (!verse) return; // Sans verset actif, on ne peut pas chercher de ponctuation
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_SILENCE,
-			onKeyDown: addSilence
-		});
+					const previousEndIndex = verse.getPreviousPunctuationMarkIndex(
+						subtitlesEditorState().endWordIndex
+					);
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_BASMALA,
-			onKeyDown: () => addPredefinedSubtitle('Basmala')
-		});
+					if (previousEndIndex === subtitlesEditorState().endWordIndex) {
+						return; // Déjà sur un signe d'arrêt, on ne bouge pas
+					}
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_ISTIADHAH,
-			onKeyDown: () => addPredefinedSubtitle('Istiadhah')
-		});
+					subtitlesEditorState().endWordIndex = previousEndIndex;
+					if (subtitlesEditorState().startWordIndex > subtitlesEditorState().endWordIndex) {
+						// Garde une sélection valide en ramenant le début sur la fin
+						subtitlesEditorState().startWordIndex = subtitlesEditorState().endWordIndex;
+					}
+				}
+			}),
 
-		ShortcutService.registerShortcut({
-			key: globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_CUSTOM_TEXT_CLIP,
-			onKeyDown: () => addCustomTextClip()
-		});
+			ADD_SUBTITLE: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.ADD_SUBTITLE,
+				onKeyDown: addSubtitle
+			}),
 
-		ShortcutService.registerShortcut({
-			key: { keys: ['Escape'], description: 'Exit subtitle editing' },
-			onKeyDown: () => (globalState.getSubtitlesEditorState.editSubtitle = null)
-		});
+			REMOVE_LAST_SUBTITLE: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.REMOVE_LAST_SUBTITLE,
+				onKeyDown: removeLastSubtitle
+			}),
+
+			EDIT_LAST_SUBTITLE: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.EDIT_LAST_SUBTITLE,
+				onKeyDown: editCurrentOrLastSubtitle
+			}),
+
+			ADD_SILENCE: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.ADD_SILENCE,
+				onKeyDown: addSilence
+			}),
+
+			ADD_BASMALA: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.ADD_BASMALA,
+				onKeyDown: () => addPredefinedSubtitle('Basmala')
+			}),
+
+			ADD_ISTIADHAH: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.ADD_ISTIADHAH,
+				onKeyDown: () => addPredefinedSubtitle('Istiadhah')
+			}),
+
+			ADD_CUSTOM_TEXT_CLIP: ShortcutService.registerShortcut({
+				key: globalState.settings.shortcuts.SUBTITLES_EDITOR.ADD_CUSTOM_TEXT_CLIP,
+				onKeyDown: () => addCustomTextClip()
+			}),
+
+			ESCAPE: ShortcutService.registerShortcut({
+				key: { keys: ['Escape'], description: 'Exit subtitle editing' },
+				onKeyDown: () => (globalState.getSubtitlesEditorState.editSubtitle = null)
+			})
+		};
+
+		return () => {
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_NEXT_WORD,
+				ids.SELECT_NEXT_WORD
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_PREVIOUS_WORD,
+				ids.SELECT_PREVIOUS_WORD
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.RESET_START_CURSOR,
+				ids.RESET_START_CURSOR
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_ALL_WORDS,
+				ids.SELECT_ALL_WORDS
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.SET_END_TO_LAST,
+				ids.SET_END_TO_LAST
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.SET_END_TO_PREVIOUS,
+				ids.SET_END_TO_PREVIOUS
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_SUBTITLE,
+				ids.ADD_SUBTITLE
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.REMOVE_LAST_SUBTITLE,
+				ids.REMOVE_LAST_SUBTITLE
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.EDIT_LAST_SUBTITLE,
+				ids.EDIT_LAST_SUBTITLE
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_SILENCE,
+				ids.ADD_SILENCE
+			);
+
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_BASMALA,
+				ids.ADD_BASMALA
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_ISTIADHAH,
+				ids.ADD_ISTIADHAH
+			);
+			ShortcutService.unregisterShortcut(
+				globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_CUSTOM_TEXT_CLIP,
+				ids.ADD_CUSTOM_TEXT_CLIP
+			);
+			ShortcutService.unregisterShortcut(
+				{ keys: ['Escape'], description: 'Exit subtitle editing' },
+				ids.ESCAPE
+			);
+		};
+	});
+
+	onMount(() => {
+		// No manual shortcuts here
 	});
 
 	onDestroy(() => {
-		// Clean up les shortcuts
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_NEXT_WORD
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_PREVIOUS_WORD
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.RESET_START_CURSOR
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.SELECT_ALL_WORDS
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.SET_END_TO_LAST
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.SET_END_TO_PREVIOUS
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_SUBTITLE
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.REMOVE_LAST_SUBTITLE
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.EDIT_LAST_SUBTITLE
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_SILENCE
-		);
-
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_BASMALA
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_ISTIADHAH
-		);
-		ShortcutService.unregisterShortcut(
-			globalState.settings!.shortcuts.SUBTITLES_EDITOR.ADD_CUSTOM_TEXT_CLIP
-		);
-		ShortcutService.unregisterShortcut({ keys: ['Escape'], description: 'Exit subtitle editing' });
+		// Clean up handled by effect
 	});
 
 	function editCurrentOrLastSubtitle(): void {

--- a/src/lib/components/projectEditor/videoPreview/VideoPreview.svelte
+++ b/src/lib/components/projectEditor/videoPreview/VideoPreview.svelte
@@ -61,6 +61,15 @@
 		resizeVideoToFitScreen();
 	});
 
+	// Effect qui redimensionne la vidéo quand on change d'onglet (ex: revenir de Translations)
+	$effect(() => {
+		const _ = globalState.currentProject?.projectEditorState.currentTab;
+		// On laisse un petit délai pour que le DOM se mette à jour (display: none -> block)
+		setTimeout(() => {
+			resizeVideoToFitScreen();
+		}, 0);
+	});
+
 	// Effect qui recharge l'audio quand l'asset audio change
 	$effect(() => {
 		if (currentAudio()) {
@@ -165,6 +174,20 @@
 	onMount(() => {
 		resizeVideoToFitScreen(); // Redimensionne initial
 		window.addEventListener('resize', resizeVideoToFitScreen); // Écoute le redimensionnement de fenêtre
+
+        // Observer le redimensionnement du conteneur parent pour gérer les changements de taille (ex: sidebar qui change)
+        const previewContainer = document.getElementById('preview-container');
+        if (previewContainer && window.ResizeObserver) {
+            const resizeObserver = new ResizeObserver(() => {
+                resizeVideoToFitScreen();
+            });
+            resizeObserver.observe(previewContainer);
+            
+            return () => {
+                resizeObserver.disconnect();
+                window.removeEventListener('resize', resizeVideoToFitScreen);
+            };
+        }
 
 		// Force la synchronisation initiale vidéo/audio avec la position du curseur
 		triggerVideoAndAudioToFitCursor();


### PR DESCRIPTION
Suppression de FontProvider : J'ai retiré ce composant car la gestion des polices et de la timeline est maintenant centralisée dans l'état global du projet (globalState). Cela rend le code plus propre et évite les rechargements inutiles.

Timeline Partagée : Comme indiqué dans le message du commit ("on share la timeline"), l'état de la timeline est désormais commun à tous les onglets (Sous-titres, Style, Export). Les changements faits dans un onglet sont immédiatement visibles dans les autres sans perte de position.

Correctif Preview Vidéo : J'ai ajouté un ResizeObserver dans VideoPreview.svelte pour s'assurer que la vidéo s'adapte correctement quand on redimensionne l'interface (par exemple avec le diviseur).

on a remis les shorcuts qui marchait plus suite aux changements de timeline partagée