### PR TITLE
feat: add video looping until audio end and fix exporter stability

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,192 @@
+# Development Documentation — Quran Caption
+
+Welcome to the **Quran Caption** development guide. This document provides a comprehensive overview
+of the project's architecture, tech stack, and development workflows to help you get started quickly
+and maintain consistency across the codebase.
+
+---
+
+## 🚀 Tech Stack
+
+Quran Caption is a desktop application built with the following modern technologies:
+
+| Layer                     | Technology                                    |
+| :------------------------ | :-------------------------------------------- |
+| **Frontend Framework**    | [Svelte 5](https://svelte.dev/) (using Runes) |
+| **Desktop Environment**   | [Tauri 2.0](https://tauri.app/) (Rust-based)  |
+| **Styling**               | [Tailwind CSS v4](https://tailwindcss.com/)   |
+| **Programming Languages** | TypeScript, Rust, Python                      |
+| **AI/ML**                 | PyTorch, Transformers (via Python sidecars)   |
+| **State Management**      | Svelte Runes + Class-based reactive models    |
+| **Build Tool**            | [Vite](https://vitejs.dev/)                   |
+| **Testing**               | [Vitest](https://vitest.dev/)                 |
+
+---
+
+## 🏗️ Architecture Overview
+
+The application follows a hybrid architecture to balance performance, UI responsiveness, and AI
+capabilities:
+
+1.  **Frontend (Svelte 5)**: Manages the user interface, video editor timeline, and visual styling.
+    It uses Svelte 5's **Runes** (`$state`, `$derived`, `$effect`) for fine-grained reactivity.
+2.  **Backend (Tauri/Rust)**: Handles file system operations, window management, and acts as a
+    bridge to the operating system. It also manages **Sidecars**.
+3.  **Sidecars (Python & Binaries)**:
+    - **Python**: Executes heavy AI tasks like audio segmentation and subtitle alignment using
+      pre-trained models.
+    - **FFmpeg/FFprobe**: Used for media processing, extraction, and exporting.
+    - **yt-dlp**: Handles video/audio downloading from external sources.
+
+---
+
+## 📂 Project Structure
+
+```text
+├── src/                    # Frontend source (SvelteKit)
+│   ├── lib/
+│   │   ├── classes/        # Domain models (Reactive classes using Runes)
+│   │   ├── components/     # UI Components
+│   │   ├── services/       # Business logic & stateful services
+│   │   └── runes/          # Global runes or shared state
+│   └── routes/             # SvelteKit pages
+├── src-tauri/              # Rust source & Tauri configuration
+│   ├── src/                # Rust backend modules
+│   │   ├── commands/       # IPC Commands callable from frontend
+│   │   ├── segmentation/   # Logic for audio/video cutting
+│   │   └── exporter/       # Frame extraction and video generation
+│   ├── python/             # Python-based AI logic (Sidecars)
+│   ├── binaries/           # External executables (ffmpeg, yt-dlp)
+│   └── tauri.conf.json     # Main configuration for Tauri
+├── static/                 # Static assets (fonts, icons, default images)
+└── scripts/                # Helper scripts for development/build
+```
+
+---
+
+## 🛠️ Setup & Installation
+
+### Prerequisites
+
+- **Node.js**: v18+ (latest LTS recommended)
+- **Rust**: Latest stable (via [rustup](https://rustup.rs/))
+- **Python**: 3.10+ (for AI features)
+- **FFmpeg & FFprobe**: Required for media processing.
+
+### Steps
+
+1.  **Clone the repository**:
+    ```bash
+    git clone https://github.com/zonetecde/QuranCaption.git
+    cd QuranCaption
+    ```
+2.  **Install Frontend Dependencies**:
+    ```bash
+    npm install
+    ```
+3.  **Setup Tauri Binaries**: Follow the instructions in
+    [`src-tauri/binaries/README.md`](src-tauri/binaries/README.md) to add `ffmpeg`, `ffprobe`, and
+    `yt-dlp` for your OS.
+4.  **Setup Python Environment** (If working on AI features):
+    ```bash
+    cd src-tauri/python
+    python -m venv venv
+    source venv/bin/activate  # or venv\Scripts\activate on Windows
+    pip install -r requirements.txt
+    ```
+
+---
+
+## 💻 Development Workflow
+
+### Commands
+
+- `npm run tauri dev`: Start the Svelte dev server and launches the Tauri desktop window.
+- `npm run dev`: Starts ONLY the Vite development server (useful for browser-only debugging).
+- `npm run tauri build`: Build the production application.
+- `npm run check`: Run Svelte-check for type-checking.
+- `npm run lint`: Lint the project using ESLint and Prettier.
+- `npm run test:unit`: Run unit tests with Vitest.
+
+### Svelte 5 & Runes
+
+We use Svelte 5's Runes exclusively for state management.
+
+- Files ending in `.svelte.ts` in `src/lib/classes` contain reactive domain logic.
+- Avoid using `writable` stores; prefer classes with `$state()` properties.
+
+### Tauri Commands (IPC)
+
+When adding new backend functionality:
+
+1.  Define a function in `src-tauri/src/commands/`.
+2.  Register it in `src-tauri/src/app/invoke.rs`.
+3.  Call it from the frontend using `@tauri-apps/api/core`:
+    ```typescript
+    import { invoke } from '@tauri-apps/api/core';
+    const result = await invoke('my_custom_command', { arg1: 'value' });
+    ```
+
+---
+
+## 🧩 Key Implementation Details
+
+### 1. Project Persistence
+
+Projects are saved as JSON files. The `ProjectService` and `Project` class handle the
+serialization/deserialization logic. We use `class-transformer` to convert plain JSON back into
+reactive class instances.
+
+### 2. Audio Segmentation
+
+The `AutoSegmentation` service communicates with the Python sidecar. It uses a custom alignment
+algorithm to detect Basmala, Istiʿādha, and verse timings. The Python script (`local_segmenter.py`)
+returns a JSON with timestamps used to create `Clip` objects.
+
+### 3. Video Rendering
+
+Exporting is handled by combining:
+
+- **Frontend**: `dom-to-image` for capturing styled verses as high-quality images.
+- **Backend (Rust)**: `ffmpeg` commands to assemble frames, audio, and background videos into the
+  final output.
+
+---
+
+## 🛠️ Utilities & Scripts
+
+The `scripts/` directory contains various Node.js scripts for data maintenance and preprocessing:
+
+- **Data Downloaders**: Scripts to fetch translations (German, Spanish, Wolof) and Surah SVGs.
+- **SVG Processing**: Tools to add padding, crop, or replace SVG images used for Quranic text.
+- **Reciter Management**: Scripts to sort, translate, and transform reciter metadata.
+- **JSON Optimization**: Tools like `simplify-qpc-json.js` to minimize the size of Quran data files.
+
+To run these scripts, use `node scripts/<script-name>.js`.
+
+---
+
+## 🚀 CI/CD
+
+The project uses **GitHub Actions** for continuous integration and automated releases.
+
+- The configuration is located in `.github/workflows/build.yml`.
+- It automatically builds and packages the application for Windows, macOS, and Linux whenever a new
+  tag is pushed.
+
+---
+
+## 🤝 Contribution Guidelines
+
+- **Atomic Commits**: Keep your commits small and focused.
+- **Code Style**: Run `npm run lint:fix` before pushing.
+- **TypeScript**: Always use strict typing. Avoid `any`.
+- **Docs**: Update this document if you change the architecture or add major modules.
+
+---
+
+## 📖 Useful Resources
+
+- [Svelte 5 Documentation](https://svelte-5-preview.vercel.app/)
+- [Tauri 2.0 Documentation](https://v2.tauri.app/)
+- [Tailwind CSS v4 Docs](https://tailwindcss.com/blog/tailwindcss-v4-alpha)

--- a/README.md
+++ b/README.md
@@ -63,10 +63,8 @@ Full documentation is available at:
 
 ### 🧩 Note for Developers
 
-After cloning the repository, ensure that you add the `ffprobe`, `ffmpeg`, and `yt-dlp` files to the
-`src-tauri/binaries` folder.
+Detailed development documentation, including setup instructions, architecture overview, and tech
+stack details, can be found in [DEVELOPMENT.md](DEVELOPMENT.md).
 
-###### 🔧 How to do that?
-
-You can find detailed instructions and download links in the
-[`src-tauri/binaries/README.md`](src-tauri/binaries/README.md) file.
+For setting up required binaries (ffmpeg, etc.), see
+[`src-tauri/binaries/README.md`](src-tauri/binaries/README.md).

--- a/src-tauri/src/exporter/commands.rs
+++ b/src-tauri/src/exporter/commands.rs
@@ -281,17 +281,18 @@ fn ffmpeg_preprocess_video(
     start_ms: Option<i32>,
     duration_ms: Option<i32>,
     blur: Option<f64>,
+    loop_video: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let (codec, params, extra) = choose_best_codec(prefer_hw);
     let exe = resolve_ffmpeg_binary().unwrap_or_else(|| "ffmpeg".to_string());
 
-    // Construire le filtre vidÃƒÂ©o avec blur optionnel
+    // Construire le filtre vidéo avec blur optionnel
     let mut vf_parts = vec![
         format!("scale=w={}:h={}:force_original_aspect_ratio=increase", w, h),
         format!("crop={}:{}:(in_w-{})/2:(in_h-{})/2", w, h, w, h),
     ];
 
-    // Ajouter le flou si spÃƒÂ©cifiÃƒÂ© et > 0
+    // Ajouter le flou si spécifié et > 0
     if let Some(blur_value) = blur {
         if blur_value > 0.0 {
             vf_parts.push(format!("gblur=sigma={}", blur_value));
@@ -305,7 +306,12 @@ fn ffmpeg_preprocess_video(
 
     let mut cmd = Command::new(&exe);
 
-    // Si un offset de dÃƒÂ©but est fourni, l'ajouter avant -i pour seek rapide
+    // Si le bouclage est activé, l'ajouter avant l'entrée
+    if loop_video {
+        cmd.arg("-stream_loop").arg("-1");
+    }
+
+    // Si un offset de début est fourni, l'ajouter avant -i pour seek rapide
     if let Some(sms) = start_ms {
         let s = format!("{:.3}", (sms as f64) / 1000.0);
         cmd.arg("-ss").arg(s);
@@ -469,7 +475,7 @@ fn is_image_file(path: &str) -> bool {
 
 /// Fonction du module export.
 fn preprocess_background_videos(
-    video_paths: &[String],
+    video_inputs: &[VideoInput],
     w: i32,
     h: i32,
     fps: i32,
@@ -483,13 +489,13 @@ fn preprocess_background_videos(
     let preproc_cache_version = "cover-v2";
     fs::create_dir_all(&cache_dir).ok();
 
-    // Cas spÃƒÂ©cial : une seule image
-    if video_paths.len() == 1 && is_image_file(&video_paths[0]) {
-        let image_path = &video_paths[0];
+    // Cas spécial : une seule image
+    if video_inputs.len() == 1 && is_image_file(&video_inputs[0].path) {
+        let image_path = &video_inputs[0].path;
         let duration_s = if let Some(dur_ms) = duration_ms {
             dur_ms as f64 / 1000.0
         } else {
-            30.0 // DurÃƒÂ©e par dÃƒÂ©faut si non spÃƒÂ©cifiÃƒÂ©e
+            30.0 // Durée par défaut si non spécifiée
         };
 
         // Construire un nom de cache unique pour l'image
@@ -524,7 +530,7 @@ fn preprocess_background_videos(
                 Ok(_) => {}
                 Err(e) => {
                     println!(
-                        "[preproc][ERREUR] Impossible de crÃƒÂ©er la vidÃƒÂ©o ÃƒÂ  partir de l'image: {:?}",
+                        "[preproc][ERREUR] Impossible de créer la vidéo à partir de l'image: {:?}",
                         e
                     );
                     return vec![];
@@ -536,46 +542,54 @@ fn preprocess_background_videos(
         return out_paths;
     }
 
-    // Calculer les durÃƒÂ©es (ms) de chaque vidÃƒÂ©o
+    // Calculer les durées (ms) de chaque vidéo
     let mut video_durations_ms: Vec<i64> = Vec::new();
-    for p in video_paths {
-        let d = (ffprobe_duration_sec(p) * 1000.0).round() as i64;
+    for input in video_inputs {
+        let d = (ffprobe_duration_sec(&input.path) * 1000.0).round() as i64;
         video_durations_ms.push(d);
     }
 
-    // Limite de la plage demandÃƒÂ©e
+    // Limite de la plage demandée
     let limit_ms: i64 = if let Some(dur) = duration_ms {
         dur as i64
     } else {
         i64::MAX
     };
 
-    // Parcourir les vidÃƒÂ©os et extraire uniquement les segments pertinents
+    // Parcourir les vidéos et extraire uniquement les segments pertinents
     let mut cum_start: i64 = 0;
-    for (idx, p) in video_paths.iter().enumerate() {
-        let vid_len = video_durations_ms.get(idx).cloned().unwrap_or(0);
+    for (idx, input) in video_inputs.iter().enumerate() {
+        let vid_path = &input.path;
+        let mut vid_len = video_durations_ms.get(idx).cloned().unwrap_or(0);
+        let is_loop = input.loop_until_audio_end.unwrap_or(false);
+
+        // Si le bouclage est activé, la vidéo peut couvrir tout le reste de la plage
+        if is_loop {
+            vid_len = limit_ms;
+        }
+
         let cum_end = cum_start + vid_len;
 
-        // Si la vidÃƒÂ©o se termine avant le dÃƒÂ©but recherchÃƒÂ©, on l'ignore complÃƒÂ¨tement
+        // Si la vidéo se termine avant le début recherché, on l'ignore complètement
         if cum_end <= start_time_ms as i64 {
             cum_start = cum_end;
             continue;
         }
 
-        // Si on a dÃƒÂ©jÃƒÂ  dÃƒÂ©passÃƒÂ© la limite demandÃƒÂ©e, on arrÃƒÂªte
+        // Si on a déjà dépassé la limite demandée, on arrête
         let elapsed_so_far = cum_start - (start_time_ms as i64);
         if elapsed_so_far >= limit_ms {
             break;
         }
 
-        // DÃƒÂ©terminer le dÃƒÂ©but ÃƒÂ  l'intÃƒÂ©rieur de cette vidÃƒÂ©o
+        // Déterminer le début à l'intérieur de cette vidéo
         let start_within = if start_time_ms as i64 > cum_start {
             start_time_ms as i64 - cum_start
         } else {
             0
         };
 
-        // DurÃƒÂ©e restante ÃƒÂ  prendre dans cette vidÃƒÂ©o
+        // Durée restante à prendre dans cette vidéo
         let elapsed_from_start = (cum_start + start_within) - (start_time_ms as i64);
         let remaining_needed = (limit_ms - elapsed_from_start).max(0);
         let take_ms = remaining_needed.min(vid_len - start_within);
@@ -585,7 +599,7 @@ fn preprocess_background_videos(
             continue;
         }
 
-        // Construire un nom de cache unique qui inclut les offsets et le blur
+        // Construire un nom de cache unique qui inclut les offsets, le blur et le flag loop
         let blur_suffix = if let Some(b) = blur {
             if b > 0.0 {
                 format!("-blur{}", b)
@@ -595,18 +609,20 @@ fn preprocess_background_videos(
         } else {
             String::new()
         };
+        let loop_suffix = if is_loop { "-loop" } else { "" };
+
         let hash_input = format!(
-            "{}-{}-{}x{}-{}-start{}-len{}{}",
-            preproc_cache_version, p, w, h, fps, start_within, take_ms, blur_suffix
+            "{}-{}-{}x{}-{}-start{}-len{}{}{}",
+            preproc_cache_version, vid_path, w, h, fps, start_within, take_ms, blur_suffix, loop_suffix
         );
         let stem_hash = format!("{:x}", md5::compute(hash_input.as_bytes()));
         let stem_hash = &stem_hash[..10.min(stem_hash.len())];
         let dst = cache_dir.join(format!("bg-{}-{}x{}-{}.mp4", stem_hash, w, h, fps));
 
         if !dst.exists() {
-            // Appeler ffmpeg_preprocess_video avec les offsets locaux
+            // Appeler ffmpeg_preprocess_video avec les offsets locaux et le flag loop
             match ffmpeg_preprocess_video(
-                p,
+                vid_path,
                 &dst.to_string_lossy(),
                 w,
                 h,
@@ -615,12 +631,13 @@ fn preprocess_background_videos(
                 Some(start_within as i32),
                 Some(take_ms as i32),
                 blur,
+                is_loop,
             ) {
                 Ok(_) => {}
                 Err(e) => {
                     println!("[preproc][ERREUR] {:?}", e);
-                    // En cas d'ÃƒÂ©chec, utiliser la vidÃƒÂ©o originale (et laisser ffmpeg final gÃƒÂ©rer le trim)
-                    out_paths.push(p.clone());
+                    // En cas d'échec, utiliser la vidéo originale
+                    out_paths.push(vid_path.clone());
                     cum_start = cum_end;
                     continue;
                 }
@@ -629,7 +646,7 @@ fn preprocess_background_videos(
 
         out_paths.push(dst.to_string_lossy().to_string());
 
-        // Si on a atteint la limite, on arrÃƒÂªte
+        // Si on a atteint la limite, on arrête
         let elapsed_total = (cum_start + start_within + take_ms) - (start_time_ms as i64);
         if elapsed_total >= limit_ms {
             break;
@@ -704,7 +721,7 @@ fn build_and_run_ffmpeg_filter_complex(
     fade_duration_ms: i32,
     start_time_ms: i32,
     audio_paths: &[String],
-    bg_videos: &[String],
+    video_inputs: &[VideoInput],
     prefer_hw: bool,
     imgs_cwd: Option<&str>,
     duration_ms: Option<i32>,
@@ -759,9 +776,9 @@ fn build_and_run_ffmpeg_filter_complex(
     let (vcodec, vparams, vextra) = choose_best_codec(prefer_hw);
 
     let mut pre_videos = Vec::new();
-    if !bg_videos.is_empty() {
+    if !video_inputs.is_empty() {
         pre_videos = preprocess_background_videos(
-            bg_videos,
+            video_inputs,
             w,
             h,
             fps,
@@ -1274,6 +1291,12 @@ fn build_and_run_ffmpeg_filter_complex(
     Ok(())
 }
 
+#[derive(serde::Deserialize, Debug)]
+pub struct VideoInput {
+    pub path: String,
+    pub loop_until_audio_end: Option<bool>,
+}
+
 #[tauri::command]
 /// Fonction du module export.
 pub async fn export_video(
@@ -1285,7 +1308,7 @@ pub async fn export_video(
     start_time: i32,
     duration: Option<i32>,
     audios: Option<Vec<String>>,
-    videos: Option<Vec<String>>,
+    videos: Option<Vec<VideoInput>>,
     chunk_index: Option<i32>,
     blur: Option<f64>,
     app: tauri::AppHandle,
@@ -1393,8 +1416,9 @@ pub async fn export_video(
     let target_size = {
         let img_data = fs::read(&files[0]).map_err(|e| format!("Erreur lecture image: {}", e))?;
         let img = image::load_from_memory(&img_data)
-            .map_err(|e| format!("Erreur dÃƒÂ©codage image: {}", e))?;
-        (img.width() as i32, img.height() as i32)
+            .map_err(|e| format!("Erreur décodage image: {}", e))?;
+        // Forcer des dimensions paires pour la compatibilité YUV420P
+        ((img.width() as i32 / 2) * 2, (img.height() as i32 / 2) * 2)
     };
 
     println!("[image] Taille cible: {}x{}", target_size.0, target_size.1);
@@ -1439,15 +1463,12 @@ pub async fn export_video(
                 .to_string()
         })
         .collect();
-    let videos_vec: Vec<String> = videos
-        .unwrap_or_default()
-        .into_iter()
-        .map(|p| {
-            path_utils::normalize_existing_path(&p)
-                .to_string_lossy()
-                .to_string()
-        })
-        .collect();
+    let mut videos_vec = videos.unwrap_or_default();
+    for v in &mut videos_vec {
+        v.path = path_utils::normalize_existing_path(&v.path)
+            .to_string_lossy()
+            .to_string();
+    }
     let app_handle = app.clone();
     let export_id_clone = export_id.clone();
 
@@ -1462,7 +1483,7 @@ pub async fn export_video(
             fade_ms,
             start_time,
             &audios_vec,
-            &videos_vec,
+            &videos_vec, // Now it's Vec<VideoInput>
             true,
             Some(&imgs_folder_resolved),
             duration,

--- a/src-tauri/src/exporter/commands.rs
+++ b/src-tauri/src/exporter/commands.rs
@@ -10,14 +10,14 @@ use std::time::Instant;
 use tauri::Emitter;
 use tokio::task;
 
-// Expose la derniÃƒÂ¨re durÃƒÂ©e d'export terminÃƒÂ©e (en secondes)
+// Expose la dernière durée d'export terminée (en secondes)
 static LAST_EXPORT_TIME_S: Mutex<Option<f64>> = Mutex::new(None);
 
 // Gestionnaire des processus actifs pour pouvoir les annuler
 static ACTIVE_EXPORTS: LazyLock<Mutex<HashMap<String, Arc<Mutex<Option<std::process::Child>>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-// Fonction utilitaire pour configurer les commandes et cacher les fenÃƒÂªtres CMD sur Windows
+// Fonction utilitaire pour configurer les commandes et cacher les fenêtres CMD sur Windows
 /// Fonction du module export.
 fn configure_command_no_window(cmd: &mut Command) {
     #[cfg(target_os = "windows")]
@@ -34,17 +34,17 @@ fn resolve_ffmpeg_binary() -> Option<String> {
         return Some(path);
     }
 
-    // En dernier recours, utiliser ffmpeg du PATH systÃƒÂ¨me
-    println!("[ffmpeg] Tentative d'utilisation de ffmpeg du systÃƒÂ¨me (PATH)");
+    // En dernier recours, utiliser ffmpeg du PATH système
+    println!("[ffmpeg] Tentative d'utilisation de ffmpeg du système (PATH)");
     if let Ok(_) = std::process::Command::new("ffmpeg")
         .arg("-version")
         .output()
     {
-        println!("[ffmpeg] Ã¢Å“â€œ FFmpeg trouvÃƒÂ© dans le PATH systÃƒÂ¨me");
+        println!("[ffmpeg] ✓ FFmpeg trouvé dans le PATH système");
         return Some("ffmpeg".to_string());
     }
 
-    // Aucun binaire FFmpeg trouvÃƒÂ©
+    // Aucun binaire FFmpeg trouvé
     None
 }
 
@@ -54,28 +54,28 @@ fn resolve_ffprobe_binary() -> String {
         return path;
     }
 
-    // En dernier recours, utiliser ffprobe du PATH systÃƒÂ¨me
-    println!("[ffprobe] Tentative d'utilisation de ffprobe du systÃƒÂ¨me (PATH)");
+    // En dernier recours, utiliser ffprobe du PATH système
+    println!("[ffprobe] Tentative d'utilisation de ffprobe du système (PATH)");
     if let Ok(_) = std::process::Command::new("ffprobe")
         .arg("-version")
         .output()
     {
-        println!("[ffprobe] Ã¢Å“â€œ FFprobe trouvÃƒÂ© dans le PATH systÃƒÂ¨me");
+        println!("[ffprobe] ✓ FFprobe trouvé dans le PATH système");
         return "ffprobe".to_string();
     }
 
-    // Fallback vers le binaire systÃƒÂ¨me
+    // Fallback vers le binaire système
     "ffprobe".to_string()
 }
 
-/// Teste si NVENC est rÃƒÂ©ellement disponible en essayant un encodage rapide
+/// Teste si NVENC est réellement disponible en essayant un encodage rapide
 fn test_nvenc_availability(ffmpeg_path: Option<&str>) -> bool {
     let exe = ffmpeg_path.unwrap_or("ffmpeg");
 
-    println!("[nvenc_test] Test de disponibilitÃƒÂ© NVENC...");
+    println!("[nvenc_test] Test de disponibilité NVENC...");
 
-    // CrÃƒÂ©er une entrÃƒÂ©e vidÃƒÂ©o de test trÃƒÂ¨s courte (1 frame noir)
-    // NVENC nÃƒÂ©cessite une rÃƒÂ©solution minimale (gÃƒÂ©nÃƒÂ©ralement 128x128 ou plus)
+    // Créer une entrée vidéo de test très courte (1 frame noir)
+    // NVENC nécessite une résolution minimale (généralement 128x128 ou plus)
     let mut cmd = Command::new(exe);
     cmd.args(&[
         "-y",
@@ -85,7 +85,7 @@ fn test_nvenc_availability(ffmpeg_path: Option<&str>) -> bool {
         "-f",
         "lavfi",
         "-i",
-        "color=c=black:s=128x128:r=1:d=0.04", // RÃƒÂ©solution minimum NVENC, trÃƒÂ¨s courte
+        "color=c=black:s=128x128:r=1:d=0.04", // Résolution minimum NVENC, très courte
         "-c:v",
         "h264_nvenc",
         "-preset",
@@ -95,7 +95,7 @@ fn test_nvenc_availability(ffmpeg_path: Option<&str>) -> bool {
         "-frames:v",
         "1",
         "-f",
-        "null", // Sortie nulle pour ÃƒÂ©viter d'ÃƒÂ©crire un fichier
+        "null", // Sortie nulle pour éviter d'écrire un fichier
         "-",
     ]);
 
@@ -107,7 +107,7 @@ fn test_nvenc_availability(ffmpeg_path: Option<&str>) -> bool {
             let stderr = String::from_utf8_lossy(&output.stderr);
 
             if success {
-                println!("[nvenc_test] Ã¢Å“â€œ NVENC disponible et fonctionnel");
+                println!("[nvenc_test] ✓ NVENC disponible et fonctionnel");
                 true
             } else {
                 // Analyser les erreurs pour distinguer "pas disponible" vs "erreur de config"
@@ -118,20 +118,20 @@ fn test_nvenc_availability(ffmpeg_path: Option<&str>) -> bool {
                     || stderr_lower.contains("cuda")
                     || stderr_lower.contains("driver")
                 {
-                    println!("[nvenc_test] Ã¢Å“â€” NVENC non disponible (pas de GPU NVIDIA ou drivers manquants)");
+                    println!("[nvenc_test] ✗ NVENC non disponible (pas de GPU NVIDIA ou drivers manquants)");
                     false
                 } else if stderr_lower.contains("frame dimension") {
-                    // Si c'est juste un problÃƒÂ¨me de dimensions, essayer avec une plus grande rÃƒÂ©solution
-                    println!("[nvenc_test] Retry avec rÃƒÂ©solution plus grande...");
+                    // Si c'est juste un problème de dimensions, essayer avec une plus grande résolution
+                    println!("[nvenc_test] Retry avec résolution plus grande...");
                     test_nvenc_with_larger_resolution(ffmpeg_path)
                 } else {
-                    println!("[nvenc_test] Ã¢Å“â€” NVENC erreur: {}", stderr.trim());
+                    println!("[nvenc_test] ✗ NVENC erreur: {}", stderr.trim());
                     false
                 }
             }
         }
         Err(e) => {
-            println!("[nvenc_test] Ã¢Å“â€” Erreur lors du test NVENC: {}", e);
+            println!("[nvenc_test] ✗ Erreur lors du test NVENC: {}", e);
             false
         }
     }
@@ -150,7 +150,7 @@ fn test_nvenc_with_larger_resolution(ffmpeg_path: Option<&str>) -> bool {
         "-f",
         "lavfi",
         "-i",
-        "color=c=black:s=256x256:r=1:d=0.04", // RÃƒÂ©solution encore plus grande
+        "color=c=black:s=256x256:r=1:d=0.04", // Résolution encore plus grande
         "-c:v",
         "h264_nvenc",
         "-preset",
@@ -170,11 +170,11 @@ fn test_nvenc_with_larger_resolution(ffmpeg_path: Option<&str>) -> bool {
         Ok(output) => {
             let success = output.status.success();
             if success {
-                println!("[nvenc_test] Ã¢Å“â€œ NVENC disponible avec rÃƒÂ©solution 256x256");
+                println!("[nvenc_test] ✓ NVENC disponible avec résolution 256x256");
             } else {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 println!(
-                    "[nvenc_test] Ã¢Å“â€” NVENC toujours non disponible: {}",
+                    "[nvenc_test] ✗ NVENC toujours non disponible: {}",
                     stderr.trim()
                 );
             }
@@ -182,7 +182,7 @@ fn test_nvenc_with_larger_resolution(ffmpeg_path: Option<&str>) -> bool {
         }
         Err(e) => {
             println!(
-                "[nvenc_test] Ã¢Å“â€” Erreur test rÃƒÂ©solution plus grande: {}",
+                "[nvenc_test] ✗ Erreur test résolution plus grande: {}",
                 e
             );
             false
@@ -228,17 +228,17 @@ fn choose_best_codec(prefer_hw: bool) -> (String, Vec<String>, HashMap<String, O
     };
 
     if !hw.is_empty() {
-        // Tester spÃƒÂ©cifiquement NVENC s'il est dÃƒÂ©tectÃƒÂ©
+        // Tester spécifiquement NVENC s'il est détecté
         if hw[0] == "h264_nvenc" {
             if test_nvenc_availability(ffmpeg_exe.as_deref()) {
-                println!("[codec] Utilisation de NVENC (accÃƒÂ©lÃƒÂ©ration GPU NVIDIA)");
+                println!("[codec] Utilisation de NVENC (accélération GPU NVIDIA)");
                 let codec = hw[0].clone();
                 let params = vec!["-pix_fmt".to_string(), "yuv420p".to_string()];
                 let mut extra = HashMap::new();
                 extra.insert("preset".to_string(), Some("fast".to_string()));
                 return (codec, params, extra);
             } else {
-                println!("[codec] NVENC dÃƒÂ©tectÃƒÂ© mais non fonctionnel, fallback vers libx264");
+                println!("[codec] NVENC détecté mais non fonctionnel, fallback vers libx264");
             }
         } else {
             // Pour les autres encodeurs hardware (QSV, AMF), utiliser directement
@@ -324,7 +324,7 @@ fn ffmpeg_preprocess_video(
         .arg("-i")
         .arg(src);
 
-    // Si une durÃƒÂ©e de dÃƒÂ©coupe est fournie, la limiter
+    // Si une durée de découpe est fournie, la limiter
     if let Some(dms) = duration_ms {
         let d = format!("{:.3}", (dms as f64) / 1000.0);
         cmd.arg("-t").arg(d);
@@ -348,7 +348,7 @@ fn ffmpeg_preprocess_video(
 
     cmd.arg(dst);
 
-    // Configurer la commande pour cacher les fenÃƒÂªtres CMD sur Windows
+    // Configurer la commande pour cacher les fenêtres CMD sur Windows
     configure_command_no_window(&mut cmd);
 
     println!(
@@ -383,13 +383,13 @@ fn create_video_from_image(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ffmpeg_exe = resolve_ffmpeg_binary().unwrap_or_else(|| "ffmpeg".to_string());
 
-    // Construire le filtre vidÃƒÂ©o avec blur optionnel
+    // Construire le filtre vidéo avec blur optionnel
     let mut vf_parts = vec![
         format!("scale={}:{}:force_original_aspect_ratio=increase", w, h),
         format!("crop={}:{}:(in_w-{})/2:(in_h-{})/2", w, h, w, h),
     ];
 
-    // Ajouter le flou si spÃƒÂ©cifiÃƒÂ© et > 0
+    // Ajouter le flou si spécifié et > 0
     if let Some(blur_value) = blur {
         if blur_value > 0.0 {
             vf_parts.push(format!("gblur=sigma={}", blur_value));
@@ -398,7 +398,7 @@ fn create_video_from_image(
 
     let video_filter = vf_parts.join(",");
 
-    // Choisir le meilleur codec avec dÃƒÂ©tection automatique
+    // Choisir le meilleur codec avec détection automatique
     let (codec, codec_params, codec_extra) = choose_best_codec(prefer_hw);
 
     let mut cmd = Command::new(&ffmpeg_exe);
@@ -426,12 +426,12 @@ fn create_video_from_image(
         cmd.arg("-preset").arg(preset);
     }
 
-    // Ajouter les paramÃƒÂ¨tres du codec
+    // Ajouter les paramètres du codec
     for param in codec_params {
         cmd.arg(param);
     }
 
-    // Ajouter des paramÃƒÂ¨tres de qualitÃƒÂ© selon le codec
+    // Ajouter des paramètres de qualité selon le codec
     if codec == "libx264" {
         cmd.args(&["-crf", "23"]);
     } else if codec.contains("nvenc") {
@@ -440,11 +440,11 @@ fn create_video_from_image(
 
     cmd.arg(output_path);
 
-    // Configurer la commande pour cacher les fenÃƒÂªtres CMD sur Windows
+    // Configurer la commande pour cacher les fenêtres CMD sur Windows
     configure_command_no_window(&mut cmd);
 
     println!(
-        "[preproc][IMG] CrÃƒÂ©ation vidÃƒÂ©o depuis image: {} -> {}",
+        "[preproc][IMG] Création vidéo depuis image: {} -> {}",
         image_path, output_path
     );
     println!("[preproc][IMG] Commande: {:?}", cmd);
@@ -673,7 +673,7 @@ fn ffprobe_duration_sec(path: &str) -> f64 {
         path,
     ]);
 
-    // Configurer la commande pour cacher les fenÃƒÂªtres CMD sur Windows
+    // Configurer la commande pour cacher les fenêtres CMD sur Windows
     configure_command_no_window(&mut cmd);
 
     let output = match cmd.output() {
@@ -800,7 +800,7 @@ fn build_and_run_ffmpeg_filter_complex(
     }
     let have_audio = !audio_paths.is_empty() && start_s < total_audio_s - 1e-6;
 
-    // PrÃƒÂ©parer le fichier concat
+    // Préparer le fichier concat
     let base_dir = if let Some(cwd) = imgs_cwd {
         PathBuf::from(cwd)
     } else {
@@ -837,7 +837,7 @@ fn build_and_run_ffmpeg_filter_complex(
         "pipe:2".to_string(),
     ]);
 
-    // EntrÃƒÂ©e unique: concat demuxer
+    // Entrée unique: concat demuxer
     let concat_name = concat_path.to_string_lossy().to_string();
 
     cmd.extend_from_slice(&[
@@ -850,14 +850,14 @@ fn build_and_run_ffmpeg_filter_complex(
     ]);
     let mut current_idx = 1;
 
-    // EntrÃƒÂ©es vidÃƒÂ©os de fond
+    // Entrées vidéos de fond
     let bg_start_idx = current_idx;
     for p in &pre_videos {
         cmd.extend_from_slice(&["-i".to_string(), p.clone()]);
         current_idx += 1;
     }
 
-    // EntrÃƒÂ©es audio
+    // Entrées audio
     let audio_start_idx = current_idx;
     if have_audio {
         for p in audio_paths {
@@ -868,7 +868,7 @@ fn build_and_run_ffmpeg_filter_complex(
 
     let mut filter_lines = Vec::new();
 
-    // Base: prÃƒÂ©parer le flux vidÃƒÂ©o unique [0:v]
+    // Base: préparer le flux vidéo unique [0:v]
     let mut split_outputs = String::new();
     for i in 0..n {
         split_outputs.push_str(&format!("[b{}]", i));
@@ -879,7 +879,7 @@ fn build_and_run_ffmpeg_filter_complex(
         w, h, w, h, fps, n, split_outputs
     ));
 
-    // Pour chaque segment, extraire la fenÃƒÂªtre temporelle et sÃƒÂ©parer couleur/alpha
+    // Pour chaque segment, extraire la fenêtre temporelle et séparer couleur/alpha
     for i in 0..n {
         let s = starts_s[i];
         let e = s + durations_s[i];
@@ -891,7 +891,7 @@ fn build_and_run_ffmpeg_filter_complex(
         filter_lines.push(format!("[s{}witha]format=yuv444p[s{}c]", i, i));
     }
 
-    // ChaÃƒÂ®ne xfade pour couleur et alpha sÃƒÂ©parÃƒÂ©ment
+    // Chaîne xfade pour couleur et alpha séparément
     let mut curr_c = "s0c".to_string();
     let mut curr_a = "s0a".to_string();
     let mut curr_duration = durations_s[0];
@@ -948,7 +948,7 @@ fn build_and_run_ffmpeg_filter_complex(
         curr_c, curr_a
     ));
 
-    // Construction de la vidÃƒÂ©o de fond [bg]
+    // Construction de la vidéo de fond [bg]
     let avail_bg_after = total_bg_s;
     let need_black_full = pre_videos.is_empty() || avail_bg_after <= 1e-6;
 
@@ -1006,7 +1006,7 @@ fn build_and_run_ffmpeg_filter_complex(
         "[bg_normalized][overlay]overlay=shortest=1:x=0:y=0,format=yuv420p[vout]"
     ));
 
-    // Audio: concat, skip start_s, clamp ÃƒÂ  duration_s
+    // Audio: concat, skip start_s, clamp à duration_s
     if have_audio {
         let a = audio_paths.len();
         if a == 1 {
@@ -1035,7 +1035,7 @@ fn build_and_run_ffmpeg_filter_complex(
 
     let filter_complex = filter_lines.join(";");
 
-    // Ãƒâ€°crit le filtergraph dans un fichier temporaire
+    // Écrit le filtergraph dans un fichier temporaire
     let tmp_dir = if let Some(cwd) = imgs_cwd {
         PathBuf::from(cwd)
     } else {
@@ -1059,7 +1059,7 @@ fn build_and_run_ffmpeg_filter_complex(
         cmd.extend_from_slice(&["-map".to_string(), "[aout]".to_string()]);
     }
 
-    // Codec vidÃƒÂ©o + audio
+    // Codec vidéo + audio
     cmd.extend_from_slice(&[
         "-r".to_string(),
         fps.to_string(),
@@ -1080,7 +1080,7 @@ fn build_and_run_ffmpeg_filter_complex(
         ]);
     }
 
-    // Assure la durÃƒÂ©e exacte
+    // Assure la durée exacte
     cmd.extend_from_slice(&["-t".to_string(), format!("{:.6}", duration_s)]);
 
     // Faststart pour formats MP4/MOV
@@ -1105,12 +1105,12 @@ fn build_and_run_ffmpeg_filter_complex(
     };
     println!("  {}", preview);
 
-    // ExÃƒÂ©cution avec capture de la progression
+    // Exécution avec capture de la progression
     let mut command = Command::new(&cmd[0]);
     command.args(&cmd[1..]);
     command.stderr(Stdio::piped());
 
-    // Configurer la commande pour cacher les fenÃƒÂªtres CMD sur Windows
+    // Configurer la commande pour cacher les fenêtres CMD sur Windows
     configure_command_no_window(&mut command);
 
     let child = command.spawn()?;
@@ -1167,7 +1167,7 @@ fn build_and_run_ffmpeg_filter_complex(
                         duration_s
                     );
 
-                    // PrÃƒÂ©parer les donnÃƒÂ©es de progression
+                    // Préparer les données de progression
                     let mut progress_data = serde_json::json!({
                         "export_id": export_id,
                         "progress": progress,
@@ -1181,7 +1181,7 @@ fn build_and_run_ffmpeg_filter_complex(
                             serde_json::Value::Number(serde_json::Number::from(chunk_idx));
                     }
 
-                    // Ãƒâ€°mettre l'ÃƒÂ©vÃƒÂ©nement de progression vers le frontend
+                    // Émettre l'événement de progression vers le frontend
                     let _ = app_handle.emit("export-progress", progress_data);
                 }
             }
@@ -1196,7 +1196,7 @@ fn build_and_run_ffmpeg_filter_complex(
         if let Some(mut child) = child_guard.take() {
             child.wait()?
         } else {
-            // Le processus a ÃƒÂ©tÃƒÂ© annulÃƒÂ©
+            // Le processus a été annulé
             let error_msg = format!("Export {} was cancelled", export_id);
             let mut error_data = serde_json::json!({
                 "export_id": export_id,
@@ -1226,7 +1226,7 @@ fn build_and_run_ffmpeg_filter_complex(
     }
 
     if !status.success() {
-        // CrÃƒÂ©er un fichier de log avec la date d'aujourd'hui
+        // Créer un fichier de log avec la date d'aujourd'hui
         let now = std::time::SystemTime::now();
         let timestamp = now
             .duration_since(std::time::UNIX_EPOCH)
@@ -1257,7 +1257,7 @@ fn build_and_run_ffmpeg_filter_complex(
             }
         );
 
-        // Ãƒâ€°crire le fichier de log
+        // Écrire le fichier de log
         if let Err(log_err) = std::fs::write(&log_filename, &log_content) {
             eprintln!("Failed to write log file {}: {}", log_filename, log_err);
         } else {
@@ -1335,12 +1335,12 @@ pub async fn export_video(
     }
 
     if let Some(ref videos) = videos {
-        println!("[video] {} fichier(s) vidÃƒÂ©o fourni(s)", videos.len());
+        println!("[video] {} fichier(s) vidéo fourni(s)", videos.len());
     } else {
-        println!("[video] aucune vidÃƒÂ©o de fond fournie");
+        println!("[video] aucune vidéo de fond fournie");
     }
 
-    // Liste des PNG triÃƒÂ©s par timestamp
+    // Liste des PNG triés par timestamp
     let folder = path_utils::normalize_existing_path(&imgs_folder);
     println!(
         "[scan] Parcours du dossier: {:?}",
@@ -1371,10 +1371,10 @@ pub async fn export_video(
         .map(|p| p.canonicalize().unwrap_or(p))
         .collect();
 
-    println!("[scan] {} image(s) trouvÃƒÂ©e(s)", files.len());
+    println!("[scan] {} image(s) trouvée(s)", files.len());
 
     if files.is_empty() {
-        return Err("Aucune image .png trouvÃƒÂ©e dans imgs_folder".to_string());
+        return Err("Aucune image .png trouvée dans imgs_folder".to_string());
     }
 
     let first_stem = files[0]
@@ -1384,7 +1384,7 @@ pub async fn export_video(
         .unwrap_or(-1);
 
     if first_stem != 0 {
-        return Err("La premiÃƒÂ¨re image doit ÃƒÂªtre '0.png' (timestamp 0 ms).".to_string());
+        return Err("La première image doit être '0.png' (timestamp 0 ms).".to_string());
     }
 
     // Timeline et chemins
@@ -1412,7 +1412,7 @@ pub async fn export_video(
     println!("[timeline] Nombre d'images: {}", ts.len());
 
     // Taille cible = taille de 0.png
-    println!("[image] Ouverture de la premiÃƒÂ¨re image pour taille cible...");
+    println!("[image] Ouverture de la première image pour taille cible...");
     let target_size = {
         let img_data = fs::read(&files[0]).map_err(|e| format!("Erreur lecture image: {}", e))?;
         let img = image::load_from_memory(&img_data)
@@ -1423,27 +1423,27 @@ pub async fn export_video(
 
     println!("[image] Taille cible: {}x{}", target_size.0, target_size.1);
 
-    // DurÃƒÂ©e totale
+    // Durée totale
     let fade_ms = fade_duration;
     let tail_ms = fade_ms.max(1000);
     let total_duration_ms = ts[ts.len() - 1] + tail_ms;
     let duration_s = total_duration_ms as f64 / 1000.0;
     println!(
-        "[timeline] DurÃƒÂ©e totale: {} ms ({:.3} s)",
+        "[timeline] Durée totale: {} ms ({:.3} s)",
         total_duration_ms, duration_s
     );
     println!(
-        "[perf] PrÃƒÂ©paration terminÃƒÂ©e en {:.0} ms",
+        "[perf] Préparation terminée en {:.0} ms",
         t0.elapsed().as_millis()
     );
 
     let out_path = path_utils::normalize_output_path(&final_file_path);
     if let Some(parent) = out_path.parent() {
         println!(
-            "[fs] CrÃƒÂ©ation du dossier de sortie si besoin: {:?}",
+            "[fs] Création du dossier de sortie si besoin: {:?}",
             parent
         );
-        fs::create_dir_all(parent).map_err(|e| format!("Erreur crÃƒÂ©ation dossier: {}", e))?;
+        fs::create_dir_all(parent).map_err(|e| format!("Erreur création dossier: {}", e))?;
     }
 
     let imgs_folder_resolved = folder
@@ -1493,12 +1493,12 @@ pub async fn export_video(
         )
     })
     .await
-    .map_err(|e| format!("Erreur tÃƒÂ¢che: {}", e))?
+    .map_err(|e| format!("Erreur tâche: {}", e))?
     .map_err(|e| format!("Erreur ffmpeg: {}", e))?;
 
     let export_time_s = t0.elapsed().as_secs_f64();
     *LAST_EXPORT_TIME_S.lock().unwrap() = Some(export_time_s);
-    println!("[done] Export terminÃƒÂ© en {:.2}s", export_time_s);
+    println!("[done] Export terminé en {:.2}s", export_time_s);
     println!("[metric] export_time_seconds={:.3}", export_time_s);
 
     // Extraire le nom de fichier de sortie
@@ -1508,7 +1508,7 @@ pub async fn export_video(
         .to_string_lossy()
         .to_string();
 
-    // PrÃƒÂ©parer les donnÃƒÂ©es de completion
+    // Préparer les données de completion
     let mut completion_data = serde_json::json!({
         "filename": output_file_name,
         "exportId": export_id,
@@ -1521,7 +1521,7 @@ pub async fn export_video(
             serde_json::Value::Number(serde_json::Number::from(chunk_idx));
     }
 
-    // Ãƒâ€°mettre l'ÃƒÂ©vÃƒÂ©nement de succÃƒÂ¨s
+    // Émettre l'événement de succès
     let _ = app.emit("export-complete", completion_data);
 
     Ok(out_path_str)
@@ -1536,7 +1536,7 @@ fn extract_time_from_ffmpeg_line(line: &str) -> Option<String> {
         if let Some(end) = line[start..].find(char::is_whitespace) {
             return Some(line[start..start + end].to_string());
         } else {
-            // Si pas d'espace trouvÃƒÂ©, prendre jusqu'ÃƒÂ  la fin
+            // Si pas d'espace trouvé, prendre jusqu'à la fin
             return Some(line[start..].to_string());
         }
     }
@@ -1557,7 +1557,7 @@ fn extract_time_from_ffmpeg_line(line: &str) -> Option<String> {
 
 /// Fonction du module export.
 fn parse_ffmpeg_time(time_str: &str) -> f64 {
-    // Si c'est dÃƒÂ©jÃƒÂ  en secondes (format dÃƒÂ©cimal)
+    // Si c'est déjà en secondes (format décimal)
     if let Ok(seconds) = time_str.parse::<f64>() {
         return seconds;
     }
@@ -1594,15 +1594,15 @@ pub fn cancel_export(export_id: String) -> Result<String, String> {
                 match child.kill() {
                     Ok(_) => {
                         println!(
-                            "[cancel_export] Processus FFmpeg tuÃƒÂ© avec succÃƒÂ¨s pour export_id: {}",
+                            "[cancel_export] Processus FFmpeg tué avec succès pour export_id: {}",
                             export_id
                         );
                         let _ = child.wait(); // Nettoyer le processus zombie
-                        Ok(format!("Export {} annulÃƒÂ© avec succÃƒÂ¨s", export_id))
+                        Ok(format!("Export {} annulé avec succès", export_id))
                     }
                     Err(e) => {
                         println!(
-                            "[cancel_export] Erreur lors de l'arrÃƒÂªt du processus: {:?}",
+                            "[cancel_export] Erreur lors de l'arrêt du processus: {:?}",
                             e
                         );
                         Err(format!("Erreur lors de l'annulation: {}", e))
@@ -1610,7 +1610,7 @@ pub fn cancel_export(export_id: String) -> Result<String, String> {
                 }
             } else {
                 println!(
-                    "[cancel_export] Aucun processus actif trouvÃƒÂ© pour export_id: {}",
+                    "[cancel_export] Aucun processus actif trouvé pour export_id: {}",
                     export_id
                 );
                 Err(format!("Aucun processus actif pour l'export {}", export_id))
@@ -1620,11 +1620,11 @@ pub fn cancel_export(export_id: String) -> Result<String, String> {
         }
     } else {
         println!(
-            "[cancel_export] Export_id non trouvÃƒÂ© dans les exports actifs: {}",
+            "[cancel_export] Export_id non trouvé dans les exports actifs: {}",
             export_id
         );
         Err(format!(
-            "Export {} non trouvÃƒÂ© ou dÃƒÂ©jÃƒÂ  terminÃƒÂ©",
+            "Export {} non trouvé ou déjà terminé",
             export_id
         ))
     }
@@ -1648,30 +1648,30 @@ pub async fn concat_videos(
     let output_path_str = output_path_buf.to_string_lossy().to_string();
 
     println!(
-        "[concat_videos] DÃƒÂ©but de la concatÃƒÂ©nation de {} vidÃƒÂ©os",
+        "[concat_videos] Début de la concaténation de {} vidéos",
         normalized_video_paths.len()
     );
     println!("[concat_videos] Fichier de sortie: {}", output_path_str);
 
     if normalized_video_paths.is_empty() {
-        return Err("Aucune vidÃƒÂ©o fournie pour la concatÃƒÂ©nation".to_string());
+        return Err("Aucune vidéo fournie pour la concaténation".to_string());
     }
 
     if normalized_video_paths.len() == 1 {
-        // Si une seule vidÃƒÂ©o, on peut simplement la copier ou la renommer
-        println!("[concat_videos] Une seule vidÃƒÂ©o, copie vers le fichier final");
+        // Si une seule vidéo, on peut simplement la copier ou la renommer
+        println!("[concat_videos] Une seule vidéo, copie vers le fichier final");
         std::fs::copy(&normalized_video_paths[0], &output_path_str)
             .map_err(|e| format!("Erreur lors de la copie: {}", e))?;
         return Ok(output_path_str);
     }
 
-    // CrÃƒÂ©er le dossier de sortie si nÃƒÂ©cessaire
+    // Créer le dossier de sortie si nécessaire
     if let Some(parent) = output_path_buf.parent() {
         fs::create_dir_all(parent)
-            .map_err(|e| format!("Erreur crÃƒÂ©ation dossier de sortie: {}", e))?;
+            .map_err(|e| format!("Erreur création dossier de sortie: {}", e))?;
     }
 
-    // CrÃƒÂ©er un fichier de liste temporaire pour FFmpeg
+    // Créer un fichier de liste temporaire pour FFmpeg
     let temp_dir = std::env::temp_dir();
     let list_file_path = temp_dir.join(format!(
         "concat_list_{}.txt",
@@ -1681,38 +1681,38 @@ pub async fn concat_videos(
             .as_secs()
     ));
 
-    // Ãƒâ€°crire la liste des fichiers ÃƒÂ  concatÃƒÂ©ner
+    // Écrire la liste des fichiers à concaténer
     let mut list_content = String::new();
     for video_path in &normalized_video_paths {
-        // VÃƒÂ©rifier que le fichier existe
+        // Vérifier que le fichier existe
         if !Path::new(video_path).exists() {
-            return Err(format!("Fichier vidÃƒÂ©o non trouvÃƒÂ©: {}", video_path));
+            return Err(format!("Fichier vidéo non trouvé: {}", video_path));
         }
         let escaped = path_utils::escape_ffconcat_path(video_path);
         list_content.push_str(&format!("file '{}'\n", escaped));
     }
 
     fs::write(&list_file_path, list_content)
-        .map_err(|e| format!("Erreur ÃƒÂ©criture fichier liste: {}", e))?;
+        .map_err(|e| format!("Erreur écriture fichier liste: {}", e))?;
 
     println!(
-        "[concat_videos] Fichier liste crÃƒÂ©ÃƒÂ©: {:?}",
+        "[concat_videos] Fichier liste créé: {:?}",
         list_file_path
     );
 
-    // PrÃƒÂ©parer la commande FFmpeg
+    // Préparer la commande FFmpeg
     let ffmpeg_exe = resolve_ffmpeg_binary().unwrap_or_else(|| "ffmpeg".to_string());
 
     let mut cmd = Command::new(&ffmpeg_exe);
     cmd.args(&[
-        "-y",           // Ãƒâ€°craser le fichier de sortie
+        "-y",           // Écraser le fichier de sortie
         "-hide_banner", // Masquer le banner FFmpeg
         "-loglevel",
         "info", // Niveau de log
         "-fflags",
-        "+genpts", // RÃƒÂ©gÃƒÂ©nÃƒÂ¨re les pts pour ÃƒÂ©viter les gaps
+        "+genpts", // Régénère les pts pour éviter les gaps
         "-f",
-        "concat", // Format d'entrÃƒÂ©e concat
+        "concat", // Format d'entrée concat
         "-safe",
         "0", // Permettre les chemins absolus
         "-i",
@@ -1720,16 +1720,16 @@ pub async fn concat_videos(
         "-avoid_negative_ts",
         "make_zero", // Normalise les timestamps
         "-map",
-        "0:v", // VidÃƒÂ©o
+        "0:v", // Vidéo
         "-c:v",
-        "copy", // Pas de rÃƒÂ©-encodage vidÃƒÂ©o
+        "copy", // Pas de ré-encodage vidéo
     ]);
 
-    // RÃƒÂ©-encoder l'audio pour lisser les timestamps et ÃƒÂ©viter les micro-cuts
+    // Ré-encoder l'audio pour lisser les timestamps et éviter les micro-cuts
     if normalized_video_paths.iter().any(|p| video_has_audio(p)) {
         cmd.args(&[
             "-map",
-            "0:a?", // Map audio si prÃƒÂ©sent (sans ÃƒÂ©chouer si absent)
+            "0:a?", // Map audio si présent (sans échouer si absent)
             "-af",
             "aresample=async=1:first_pts=0", // Corrige les horloges audio
             "-c:a",
@@ -1738,19 +1738,19 @@ pub async fn concat_videos(
             "192k",
         ]);
     } else {
-        cmd.arg("-an"); // Aucun audio trouvÃƒÂ©, on dÃƒÂ©sactive l'audio
+        cmd.arg("-an"); // Aucun audio trouvé, on désactive l'audio
     }
 
     cmd.arg(&output_path_str); // Fichier de sortie
 
-    // Configurer la commande pour cacher les fenÃƒÂªtres CMD sur Windows
+    // Configurer la commande pour cacher les fenêtres CMD sur Windows
     configure_command_no_window(&mut cmd);
 
-    println!("[concat_videos] ExÃƒÂ©cution de FFmpeg...");
+    println!("[concat_videos] Exécution de FFmpeg...");
 
     let output = cmd
         .output()
-        .map_err(|e| format!("Erreur exÃƒÂ©cution FFmpeg: {}", e))?;
+        .map_err(|e| format!("Erreur exécution FFmpeg: {}", e))?;
 
     // Nettoyer le fichier temporaire
     let _ = fs::remove_file(&list_file_path);
@@ -1764,19 +1764,19 @@ pub async fn concat_videos(
         println!("STDERR: {}", stderr);
 
         return Err(format!(
-            "FFmpeg a ÃƒÂ©chouÃƒÂ© lors de la concatÃƒÂ©nation (code: {:?})\nSTDERR: {}",
+            "FFmpeg a échoué lors de la concaténation (code: {:?})\nSTDERR: {}",
             output.status.code(),
             stderr
         ));
     }
 
-    // VÃƒÂ©rifier que le fichier de sortie a ÃƒÂ©tÃƒÂ© crÃƒÂ©ÃƒÂ©
+    // Vérifier que le fichier de sortie a été créé
     if !Path::new(&output_path_str).exists() {
-        return Err("Le fichier de sortie n'a pas ÃƒÂ©tÃƒÂ© crÃƒÂ©ÃƒÂ©".to_string());
+        return Err("Le fichier de sortie n'a pas été créé".to_string());
     }
 
     println!(
-        "[concat_videos] Ã¢Å“â€¦ ConcatÃƒÂ©nation rÃƒÂ©ussie: {}",
+        "[concat_videos] ✅ Concaténation réussie: {}",
         output_path_str
     );
     Ok(output_path_str)

--- a/src/lib/classes/Asset.svelte.ts
+++ b/src/lib/classes/Asset.svelte.ts
@@ -66,10 +66,11 @@ export class Asset extends SerializableBase {
 	}
 
 	async addToTimeline(asVideo: boolean, asAudio: boolean) {
-		if (asVideo) globalState.getVideoTrack.addAsset(this);
+		let wasAddedToVideo = false;
+		if (asVideo) wasAddedToVideo = globalState.getVideoTrack.addAsset(this);
 		if (asAudio) globalState.getAudioTrack.addAsset(this);
 
-		if (asVideo && this.type === AssetType.Video) {
+		if (asVideo && wasAddedToVideo && this.type === AssetType.Video) {
 			// Demande à l'utilisateur s'il veut que le format de les dimensions de la vidéo soient appliquées au projet
 			// Récupère les dimensions de la vidéo
 			const assetDimensions = (await invoke('get_video_dimensions', {

--- a/src/lib/classes/Clip.svelte.ts
+++ b/src/lib/classes/Clip.svelte.ts
@@ -506,7 +506,6 @@ export class PredefinedSubtitleClip extends ClipWithTranslation {
 			return qpcVersion ? QPCFontProvider.getSadaqaGlyph() : super.getText();
 		}
 
-
 		// Si on a pas une police avec les caracteres speciaux
 		if (!qpcVersion) {
 			return super.getText();
@@ -601,4 +600,3 @@ export class CustomImageClip extends CustomClip {
 SerializableBase.registerChildClass(SubtitleClip, 'translations', Translation);
 SerializableBase.registerChildClass(ClipWithTranslation, 'translations', Translation);
 SerializableBase.registerChildClass(CustomTextClip, 'translations', Translation);
-

--- a/src/lib/classes/Clip.svelte.ts
+++ b/src/lib/classes/Clip.svelte.ts
@@ -144,6 +144,7 @@ export class Clip extends SerializableBase {
 
 export class AssetClip extends Clip {
 	assetId: number;
+	loopUntilAudioEnd: boolean = $state(false);
 
 	constructor(startTime: number, endTime: number, assetId: number) {
 		super(startTime, endTime, 'Asset');

--- a/src/lib/classes/Timeline.svelte.ts
+++ b/src/lib/classes/Timeline.svelte.ts
@@ -15,6 +15,23 @@ export class Timeline extends SerializableBase {
 		return new Duration(Math.max(...this.tracks.map((track) => track.getDuration().ms)));
 	}
 
+	getLongestTrackDurationIgnoringLoopedVideo(): Duration {
+		return new Duration(
+			Math.max(
+				...this.tracks.map((track) => {
+					if (track.type === TrackType.Video) {
+						const nonLoopedClips = track.clips.filter(
+							(clip) => !(clip instanceof AssetClip && clip.loopUntilAudioEnd)
+						);
+						if (nonLoopedClips.length === 0) return 0;
+						return Math.max(...nonLoopedClips.map((clip) => clip.endTime));
+					}
+					return track.getDuration().ms;
+				})
+			)
+		);
+	}
+
 	removeAssetFromTracks(asset: Asset) {
 		this.tracks.forEach((track) => {
 			if (track.type === TrackType.Audio || track.type === TrackType.Video) {

--- a/src/lib/classes/Track.svelte.ts
+++ b/src/lib/classes/Track.svelte.ts
@@ -179,7 +179,7 @@ export class AssetTrack extends Track {
 			if (this.clips.some((c) => c instanceof AssetClip && (c as AssetClip).loopUntilAudioEnd)) {
 				ModalManager.errorModal(
 					'Clip Addition Error',
-					'You cannot add more clips because a clip with "Loop until audio end" is already present.'
+					'You cannot add more clips because a clip with "Loop until the end" is already present.'
 				);
 				return false;
 			}
@@ -248,7 +248,10 @@ export class SubtitleTrack extends Track {
 
 		// Modiife le clip existant ou le remplace par le nouveau clip pré-défini
 		if (newSubtitleClip) {
-			if (newSubtitleClip instanceof ClipWithTranslation && subtitle instanceof ClipWithTranslation) {
+			if (
+				newSubtitleClip instanceof ClipWithTranslation &&
+				subtitle instanceof ClipWithTranslation
+			) {
 				newSubtitleClip.associatedImagePath = subtitle.associatedImagePath;
 			}
 

--- a/src/lib/classes/Track.svelte.ts
+++ b/src/lib/classes/Track.svelte.ts
@@ -170,11 +170,20 @@ export class AssetTrack extends Track {
 		super(type);
 	}
 
-	addAsset(asset: Asset) {
+	addAsset(asset: Asset): boolean {
 		// Récupère le dernier clip de la piste, s'il existe
 		const lastClip = this.clips.length > 0 ? this.clips[this.clips.length - 1] : null;
 
 		if (lastClip) {
+			// Prevent adding if an existing clip has the loop option enabled
+			if (this.clips.some((c) => c instanceof AssetClip && (c as AssetClip).loopUntilAudioEnd)) {
+				ModalManager.errorModal(
+					'Clip Addition Error',
+					'You cannot add more clips because a clip with "Loop until audio end" is already present.'
+				);
+				return false;
+			}
+
 			// S'il y a un dernier clip alors qu'on essaie de mettre une image dans la timeline (= mettre une image en
 			// tant que background pour la vidéo), alors on informe l'utilisateur que ce n'est pas possible.
 			if (asset.type === AssetType.Image) {
@@ -182,7 +191,7 @@ export class AssetTrack extends Track {
 					'Background Image Error',
 					'You cannot add a background image to the timeline because there is already a video or image clip in the video track.'
 				);
-				return;
+				return false;
 			}
 
 			this.clips.push(
@@ -196,6 +205,8 @@ export class AssetTrack extends Track {
 
 			globalState.getTimelineState.movePreviewTo = globalState.getTimelineState.cursorPosition + 1;
 		}, 0);
+
+		return true;
 	}
 }
 

--- a/src/lib/components/projectEditor/timeline/Timeline.svelte
+++ b/src/lib/components/projectEditor/timeline/Timeline.svelte
@@ -2,7 +2,7 @@
 	import { globalState } from '$lib/runes/main.svelte';
 	import { onDestroy, onMount, untrack } from 'svelte';
 	import Track from './track/Track.svelte';
-	import { Duration, TrackType, ProjectEditorTabs, SubtitleClip } from '$lib/classes';
+	import { Duration, TrackType, ProjectEditorTabs, SubtitleClip, AssetClip } from '$lib/classes';
 	import { slide } from 'svelte/transition';
 	import ShortcutService from '$lib/services/ShortcutService';
 
@@ -275,6 +275,23 @@
 			registerRemoveShortcut();
 		} else {
 			unregisterRemoveShortcut();
+		}
+
+		// Le raccourci de synchronisation des clips bouclés
+		if (globalState.currentProject) {
+			const timeline = globalState.currentProject.content.timeline;
+			const longestMs = timeline.getLongestTrackDurationIgnoringLoopedVideo().ms;
+
+			const videoTrack = timeline.tracks.find((t) => t.type === TrackType.Video);
+			if (videoTrack) {
+				const loopedClip = videoTrack.clips.find(
+					(clip) => clip instanceof AssetClip && (clip as AssetClip).loopUntilAudioEnd
+				);
+
+				if (loopedClip && loopedClip.endTime !== longestMs) {
+					loopedClip.setEndTime(longestMs);
+				}
+			}
 		}
 
 		// Le raccourci M pour définir la fin du sous-titre fonctionne dans tous les tabs maintenant

--- a/src/lib/components/projectEditor/timeline/track/Clip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/Clip.svelte
@@ -8,6 +8,7 @@
 	import ContextMenu, { Item, Divider, Settings } from 'svelte-contextmenu';
 	import { currentMenu } from 'svelte-contextmenu/stores';
 	import { WaveformService } from '$lib/services/WaveformService.svelte.js';
+	import ModalManager from '$lib/components/modals/ModalManager';
 
 	let {
 		clip = $bindable(),
@@ -85,6 +86,35 @@
 			track.removeClip(clip.id);
 		});
 	}
+	function loopUntilTheEndClicked(): void {
+		const assetClip = clip as AssetClip;
+		const willEnable = !assetClip.loopUntilAudioEnd;
+		assetClip.loopUntilAudioEnd = willEnable;
+
+		if (assetClip.loopUntilAudioEnd) {
+			// If there are other clips in the track, the loop cannot be activated.
+			if (track.clips.length > 1) {
+				assetClip.loopUntilAudioEnd = false;
+				ModalManager.errorModal(
+					'Looping Error',
+					'You can only enable "Loop until the end" if this is the only clip in the track.'
+				);
+				return;
+			}
+
+			if (globalState.currentProject) {
+				assetClip.setEndTime(
+					globalState.currentProject.content.timeline.getLongestTrackDurationIgnoringLoopedVideo()
+						.ms
+				);
+			}
+		} else {
+			const asset = globalState.currentProject?.content.getAssetById(assetClip.assetId);
+			if (asset) {
+				assetClip.setEndTime(assetClip.startTime + asset.duration.ms);
+			}
+		}
+	}
 </script>
 
 <div
@@ -124,35 +154,12 @@
 
 <ContextMenu bind:this={contextMenu}>
 	{#if track.type === TrackType.Video && clip instanceof AssetClip}
-		<Item
-			on:click={() => {
-				const assetClip = clip as AssetClip;
-				assetClip.loopUntilAudioEnd = !assetClip.loopUntilAudioEnd;
-				if (assetClip.loopUntilAudioEnd) {
-					// If there are other clips in the track, the loop cannot be activated.
-					if (track.clips.length > 1) {
-						assetClip.loopUntilAudioEnd = false;
-						ModalManager.errorModal(
-							'Looping Error',
-							'You can only enable "Loop until audio end" if this is the only clip in the track.'
-						);
-						return;
-					}
-
-					if (globalState.currentProject) {
-						assetClip.setEndTime(
-							globalState.currentProject.content.timeline.getLongestTrackDurationIgnoringLoopedVideo()
-								.ms
-						);
-					}
-				}
-			}}
-		>
+		<Item on:click={loopUntilTheEndClicked}>
 			<div class="btn-icon">
 				<span class="material-icons-outlined text-sm mr-1">
 					{(clip as AssetClip).loopUntilAudioEnd ? 'check_box' : 'check_box_outline_blank'}
 				</span>
-				Loop until audio end
+				Loop until the end
 			</div>
 		</Item>
 		<Divider />

--- a/src/lib/components/projectEditor/timeline/track/Clip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/Clip.svelte
@@ -129,11 +129,21 @@
 				const assetClip = clip as AssetClip;
 				assetClip.loopUntilAudioEnd = !assetClip.loopUntilAudioEnd;
 				if (assetClip.loopUntilAudioEnd) {
-					const audioTrack = globalState.currentProject?.content.timeline.getFirstTrack(
-						TrackType.Audio
-					);
-					if (audioTrack) {
-						assetClip.setEndTime(audioTrack.getDuration().ms);
+					// If there are other clips in the track, the loop cannot be activated.
+					if (track.clips.length > 1) {
+						assetClip.loopUntilAudioEnd = false;
+						ModalManager.errorModal(
+							'Looping Error',
+							'You can only enable "Loop until audio end" if this is the only clip in the track.'
+						);
+						return;
+					}
+
+					if (globalState.currentProject) {
+						assetClip.setEndTime(
+							globalState.currentProject.content.timeline.getLongestTrackDurationIgnoringLoopedVideo()
+								.ms
+						);
 					}
 				}
 			}}

--- a/src/lib/components/projectEditor/timeline/track/Clip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/Clip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { AssetType, TrackType, type AssetClip, type Clip, type Track } from '$lib/classes';
+	import { AssetType, TrackType, AssetClip, type Clip, type Track } from '$lib/classes';
 	import { globalState } from '$lib/runes/main.svelte';
 	import { convertFileSrc } from '@tauri-apps/api/core';
 	import { onDestroy, onMount, untrack } from 'svelte';
@@ -123,6 +123,30 @@
 </div>
 
 <ContextMenu bind:this={contextMenu}>
+	{#if track.type === TrackType.Video && clip instanceof AssetClip}
+		<Item
+			on:click={() => {
+				const assetClip = clip as AssetClip;
+				assetClip.loopUntilAudioEnd = !assetClip.loopUntilAudioEnd;
+				if (assetClip.loopUntilAudioEnd) {
+					const audioTrack = globalState.currentProject?.content.timeline.getFirstTrack(
+						TrackType.Audio
+					);
+					if (audioTrack) {
+						assetClip.setEndTime(audioTrack.getDuration().ms);
+					}
+				}
+			}}
+		>
+			<div class="btn-icon">
+				<span class="material-icons-outlined text-sm mr-1">
+					{(clip as AssetClip).loopUntilAudioEnd ? 'check_box' : 'check_box_outline_blank'}
+				</span>
+				Loop until audio end
+			</div>
+		</Item>
+		<Divider />
+	{/if}
 	<Item on:click={removeClip}
 		><div class="btn-icon">
 			<span class="material-icons-outlined text-sm mr-1">remove</span>Remove clip

--- a/src/lib/components/projectEditor/videoPreview/VideoPreview.svelte
+++ b/src/lib/components/projectEditor/videoPreview/VideoPreview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Asset, AssetType, ProjectEditorTabs, TrackType } from '$lib/classes';
+	import { Asset, AssetType, ProjectEditorTabs, TrackType, AssetClip } from '$lib/classes';
 	import { globalState } from '$lib/runes/main.svelte';
 	import { convertFileSrc } from '@tauri-apps/api/core';
 	import { mount, onDestroy, onMount, unmount, untrack } from 'svelte';
@@ -47,6 +47,23 @@
 			return untrack(() => {
 				return globalState.currentProject!.content.timeline.getCurrentAssetOnTrack(TrackType.Audio);
 			});
+	});
+
+	let currentVideoClip = $derived(() => {
+		if (!globalState.currentProject) return null;
+		try {
+			const track = globalState.currentProject.content.timeline.tracks.find(
+				(t) => t.type === TrackType.Video
+			);
+			return track?.getCurrentClip() ?? null;
+		} catch (e) {
+			return null;
+		}
+	});
+
+	let isVideoLooping = $derived(() => {
+		const clip = currentVideoClip();
+		return clip instanceof AssetClip && clip.loopUntilAudioEnd;
 	});
 
 	// === ÉTATS LOCAUX ===
@@ -144,11 +161,18 @@
 	 */
 	function getCurrentVideoTimeToPlay(): number {
 		const currentClip = globalState.getVideoTrack.getCurrentClip();
+		const asset = currentVideo();
 
-		if (!currentClip) return 0;
+		if (!currentClip || !asset) return 0;
 
 		// Le temps dans la vidéo = position du curseur - début du clip
-		const timeInClip = getTimelineSettings().movePreviewTo - currentClip.startTime;
+		const refTime = getTimelineSettings().movePreviewTo ?? getTimelineSettings().cursorPosition;
+		let timeInClip = refTime - currentClip.startTime;
+
+		if (isVideoLooping() && !asset.duration.isNull()) {
+			timeInClip = timeInClip % asset.duration.ms;
+		}
+
 		return Math.max(0, timeInClip / 1000); // Convertit en secondes pour l'élément video HTML
 	}
 
@@ -304,11 +328,15 @@
 
 		// Utilise la vidéo pour mettre à jour le curseur de la timeline
 		if (videoElement && videoElement.currentTime !== undefined && isPlaying) {
-			const currentVideoClip = globalState.getVideoTrack.getCurrentClip();
+			const currentClip = globalState.getVideoTrack.getCurrentClip();
 
-			if (currentVideoClip) {
+			if (currentClip) {
+				if (isVideoLooping()) {
+					return;
+				}
+
 				// La position du curseur = début du clip + temps écoulé dans la vidéo (en ms)
-				const absolutePosition = currentVideoClip.startTime + videoElement.currentTime * 1000;
+				const absolutePosition = currentClip.startTime + videoElement.currentTime * 1000;
 				getTimelineSettings().cursorPosition = absolutePosition;
 			}
 		}
@@ -592,6 +620,10 @@
 			return;
 		}
 
+		if (!currentAudio() && isVideoLooping()) {
+			playSilentAudio();
+		}
+
 		isPlaying = true;
 		globalState.getVideoPreviewState.isPlaying = true;
 
@@ -748,6 +780,7 @@
 						bind:this={videoElement}
 						src={convertFileSrc(currentVideo()!.filePath)}
 						muted
+						loop={isVideoLooping()}
 						onended={goNextVideo}
 					></video>
 				{:else if currentImage()}

--- a/src/routes/exporter/+page.svelte
+++ b/src/routes/exporter/+page.svelte
@@ -434,9 +434,10 @@
 		);
 
 		// Récupère le chemin de fichier de toutes les vidéos du projet
-		const videos = globalState.getVideoTrack.clips.map(
-			(clip: any) => globalState.currentProject!.content.getAssetById(clip.assetId).filePath
-		);
+		const videos = globalState.getVideoTrack.clips.map((clip: any) => ({
+			path: globalState.currentProject!.content.getAssetById(clip.assetId).filePath,
+			loop_until_audio_end: clip.loopUntilAudioEnd
+		}));
 
 		const chunkVideoFileName = `chunk_${chunkIndex}_video.mp4`;
 		const chunkFinalFilePath = await join(
@@ -816,9 +817,10 @@
 		);
 
 		// Récupère le chemin de fichier de toutes les vidéos du projet
-		const videos = globalState.getVideoTrack.clips.map(
-			(clip: any) => globalState.currentProject!.content.getAssetById(clip.assetId).filePath
-		);
+		const videos = globalState.getVideoTrack.clips.map((clip: any) => ({
+			path: globalState.currentProject!.content.getAssetById(clip.assetId).filePath,
+			loop_until_audio_end: clip.loopUntilAudioEnd
+		}));
 
 		console.log(exportData!.finalFilePath);
 


### PR DESCRIPTION

This PR introduces the "Loop until audio end" feature for background video clips and addresses
several critical bugs in the exportation process to ensure high stability across different project
sizes and UI scales.

Fixes #74 

### ✨ Key Features & Fixes

- **Video Looping**:
  - Right-click a video clip in the timeline to toggle **"Loop until audio end"**.
  - The clip automatically extends to the end of the total recitation.
  - The Rust backend now uses `-stream_loop -1` in FFmpeg to handle the looping logic during
    preprocessing.
- **Export Stability (Resolution Fix)**:
  - Added logic to force **even dimensions** (even width/height) during the start of an export.
  - This fixes the `Invalid argument` error in FFmpeg caused by the `yuv420p` pixel format requiring
    dimensions divisible by 2 (e.g., forcing a 2557px height down to 2556px).
- **Runtime Fixes**:
  - Fixed a `ReferenceError: AssetClip is not defined` in `Clip.svelte` caused by importing
    `AssetClip` as a type only when it was needed as a value for `instanceof` checks.
- **New Documentation**:
  - Added **`DEVELOPMENT.md`**: A comprehensive guide covering the project's architecture, tech
    stack (Svelte 5 Runes, Tauri 2.0, Rust, Python), and development workflows.

### 🧪 How to Test

1.  Open any project with an audio recitation.
2.  Add a video clip to the Video track.
3.  Right-click the clip and select **"Loop until audio end"**.
4.  Ensure the clip visualizes correctly on the timeline.
5.  Start an export and verify that:
    - FFmpeg does not crash due to odd resolution.
    - The video loops smoothly until the end of the final video.