### PR TITLE
perf(timing): slice timestamp request windows

### DIFF
--- a/src/lib/classes/Clip.svelte.ts
+++ b/src/lib/classes/Clip.svelte.ts
@@ -908,6 +908,7 @@ export function getForcedFontForPredefinedSubtitle(
 
 export class PredefinedSubtitleClip extends ClipWithTranslation {
 	predefinedSubtitleType: PredefinedSubtitleType = $state('Other');
+	alignmentMetadata: SubtitleAlignmentMetadata | null = $state(null);
 
 	constructor(
 		startTime: number = 0,

--- a/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
@@ -17,6 +17,7 @@
 	import toast from 'svelte-5-french-toast';
 	import {
 		computeWbwTimestampsForClips,
+		isWbwTimestampClip,
 		scheduleWbwRealign,
 		getAutoRealignStatus,
 		AUTO_REALIGN_DRAG_THRESHOLD_MS
@@ -40,7 +41,7 @@
 
 	// Vrai si ce sous-titre Quran n'a pas encore de timestamps mot à mot.
 	let isMissingWbwTimestamps = $derived(
-		clip instanceof SubtitleClip && (clip.alignmentMetadata?.words.length ?? 0) === 0
+		isWbwTimestampClip(clip) && (clip.alignmentMetadata?.words.length ?? 0) === 0
 	);
 
 	let positionLeft = $derived(() => {
@@ -156,7 +157,7 @@
 	}
 
 	const wordBoundaryMarkers = $derived(() => {
-		if (!(clip instanceof SubtitleClip)) return [];
+		if (!isWbwTimestampClip(clip)) return [];
 		if ((clip.alignmentMetadata?.words.length ?? 0) === 0) return [];
 
 		const clipDurationMs = Math.max(1, clip.endTime - clip.startTime);
@@ -453,7 +454,7 @@
 	 * @returns {Promise<void>}
 	 */
 	async function generateWbwTimestampsFromContextMenu(): Promise<void> {
-		if (!(clip instanceof SubtitleClip)) return;
+		if (!isWbwTimestampClip(clip)) return;
 
 		currentMenu.set(null);
 		await tick();
@@ -750,6 +751,15 @@
 			</div></Item
 		>
 	{/if}
+	{#if isMissingWbwTimestamps}
+		<Divider />
+		<Item on:click={generateWbwTimestampsFromContextMenu}
+			><div class="btn-icon">
+				<span class="material-icons-outlined text-sm mr-1">auto_awesome</span>Generate WBW
+				timestamps
+			</div></Item
+		>
+	{/if}
 	{#if clip.type === 'Subtitle'}
 		<Divider />
 		<Item on:click={editSubtitleFromQuickEditorContextMenu}
@@ -764,14 +774,6 @@
 				>{$LL.editor.editTranslationContext()}
 			</div></Item
 		>
-		{#if isMissingWbwTimestamps}
-			<Item on:click={generateWbwTimestampsFromContextMenu}
-				><div class="btn-icon">
-					<span class="material-icons-outlined text-sm mr-1">auto_awesome</span>Generate WBW
-					timestamps
-				</div></Item
-			>
-		{/if}
 		<Item on:click={editWbwTimestampFromContextMenu}
 			><div class="btn-icon">
 				<span class="material-icons-outlined text-sm mr-1">timeline</span

--- a/src/lib/services/AutoSegmentation.ts
+++ b/src/lib/services/AutoSegmentation.ts
@@ -50,15 +50,13 @@ export {
 	getSubtitleClipsWithoutWbwTimestamps,
 	markSubtitlesWithoutWbwTimestampsForReview,
 	clearWbwTimestampReview,
+	computeRealignWindow,
 	computeMissingWbwTimestamps,
 	computeWbwTimestampsForClips,
-	computeWbwTimestampsForClipsSliced
+	computeWbwTimestampsForClipsSliced,
+	isWbwTimestampClip
 } from './autoSegmentation/review';
-export {
-	scheduleWbwRealign,
-	getAutoRealignStatus,
-	computeRealignWindow
-} from './autoSegmentation/auto-realign.svelte';
+export { scheduleWbwRealign, getAutoRealignStatus } from './autoSegmentation/auto-realign.svelte';
 export {
 	hydrateSubtitleClipRange,
 	splitSubtitleClipLocally,

--- a/src/lib/services/autoSegmentation/auto-realign.svelte.ts
+++ b/src/lib/services/autoSegmentation/auto-realign.svelte.ts
@@ -1,8 +1,8 @@
 import { SubtitleClip } from '$lib/classes';
 import { globalState } from '$lib/runes/main.svelte';
 import { getAutoSegmentationAudioClips } from './audio';
-import { computeWbwTimestampsForClipsSliced } from './review';
-import { AUTO_REALIGN_DEBOUNCE_MS, AUTO_REALIGN_TIMEOUT_MS, type RealignWindow } from './types';
+import { computeRealignWindow, computeWbwTimestampsForClipsSliced } from './review';
+import { AUTO_REALIGN_DEBOUNCE_MS, AUTO_REALIGN_TIMEOUT_MS } from './types';
 
 /**
  * Re-alignement WBW automatique et « abstrait » déclenché par les éditions de sous-titres.
@@ -39,22 +39,6 @@ const pendingGroups = new Map<string, PendingGroup>();
  */
 export function getAutoRealignStatus(clipId: number): AutoRealignStatus {
 	return statusByClipId[clipId] ? 'computing' : 'idle';
-}
-
-/**
- * Calcule la fenêtre audio (ms, coordonnées timeline) couvrant un ensemble de clips consécutifs.
- *
- * @param {SubtitleClip[]} clips Clips concernés.
- * @returns {RealignWindow} Fenêtre `[startMs, endMs]` à trancher/téléverser.
- */
-export function computeRealignWindow(clips: SubtitleClip[]): RealignWindow {
-	const starts = clips.map((clip) =>
-		Math.round((clip.alignmentMetadata?.timeFrom ?? clip.startTime / 1000) * 1000)
-	);
-	const ends = clips.map((clip) =>
-		Math.round((clip.alignmentMetadata?.timeTo ?? clip.endTime / 1000) * 1000)
-	);
-	return { startMs: Math.min(...starts), endMs: Math.max(...ends) };
 }
 
 /**

--- a/src/lib/services/autoSegmentation/context.ts
+++ b/src/lib/services/autoSegmentation/context.ts
@@ -167,6 +167,23 @@ export function refreshSegmentationContextFromTrack(preserveAudioId: boolean): v
 			continue;
 		}
 
+		if (rawClip instanceof PredefinedSubtitleClip && rawClip.alignmentMetadata) {
+			const metadata = rawClip.alignmentMetadata;
+			alignedSegments.push({
+				clipId: rawClip.id,
+				type: 'Pre-defined Subtitle',
+				startMs: rawClip.startTime,
+				endMs: rawClip.endTime,
+				segment: metadata.segment,
+				refFrom: metadata.refFrom,
+				refTo: metadata.refTo,
+				matchedText: metadata.matchedText,
+				specialType: metadata.specialType,
+				words: metadata.words.map((word) => ({ ...word }))
+			});
+			continue;
+		}
+
 		if (rawClip instanceof PredefinedSubtitleClip) {
 			const existing = existingById.get(rawClip.id);
 			if (existing) {

--- a/src/lib/services/autoSegmentation/review.ts
+++ b/src/lib/services/autoSegmentation/review.ts
@@ -1,8 +1,25 @@
 import { globalState } from '$lib/runes/main.svelte';
-import { SubtitleClip } from '$lib/classes';
+import { PredefinedSubtitleClip, SubtitleClip } from '$lib/classes';
 import type { RealignWindow, SegmentationSegment } from './types';
 import { enrichSegmentationResponseWithWordTimestamps } from './enrichment';
 import { buildSubtitleAlignmentMetadata, refreshSegmentationContextFromTrack } from './context';
+import { ProjectHistoryManager } from '$lib/services/undoRedo/ProjectHistoryManager';
+
+type WbwTimestampClip = SubtitleClip | PredefinedSubtitleClip;
+
+/**
+ * Indique si un clip peut recevoir des timestamps mot à mot.
+ *
+ * @param {unknown} clip Clip à inspecter.
+ * @returns {boolean} `true` pour un sous-titre Quran ou une Basmala/Isti'adha prédéfinie.
+ */
+export function isWbwTimestampClip(clip: unknown): clip is WbwTimestampClip {
+	return (
+		clip instanceof SubtitleClip ||
+		(clip instanceof PredefinedSubtitleClip &&
+			(clip.predefinedSubtitleType === 'Basmala' || clip.predefinedSubtitleType === "Isti'adha"))
+	);
+}
 
 /**
  * Compte le nombre de mots Quran couverts par un sous-titre.
@@ -84,10 +101,11 @@ export function clearLongSegmentsReview(): void {
 /**
  * Retourne les segments Quran qui n'ont pas encore de timestamps WBW.
  *
- * @returns {SubtitleClip[]} Liste triée des sous-titres sans timestamps WBW.
+ * @returns {WbwTimestampClip[]} Liste triée des sous-titres sans timestamps WBW.
  */
-export function getSubtitleClipsWithoutWbwTimestamps(): SubtitleClip[] {
-	return globalState.getSubtitleClips
+export function getSubtitleClipsWithoutWbwTimestamps(): WbwTimestampClip[] {
+	return globalState.getSubtitleTrack.clips
+		.filter(isWbwTimestampClip)
 		.filter((clip) => (clip.alignmentMetadata?.words.length ?? 0) === 0)
 		.sort((left, right) => left.startTime - right.startTime);
 }
@@ -100,7 +118,7 @@ export function getSubtitleClipsWithoutWbwTimestamps(): SubtitleClip[] {
 export function markSubtitlesWithoutWbwTimestampsForReview(): number {
 	let markedCount = 0;
 
-	for (const clip of globalState.getSubtitleClips) {
+	for (const clip of globalState.getSubtitleTrack.clips.filter(isWbwTimestampClip)) {
 		const hasWbwTimestamps = (clip.alignmentMetadata?.words.length ?? 0) > 0;
 		if (hasWbwTimestamps) {
 			clip.needsWbwTimestampReview = false;
@@ -125,10 +143,26 @@ export function clearWbwTimestampReview(): void {
 }
 
 /**
+ * Calcule la fenêtre audio (ms, coordonnées timeline) couvrant un ensemble de clips.
+ *
+ * @param {WbwTimestampClip[]} clips Clips concernés.
+ * @returns {RealignWindow} Fenêtre `[startMs, endMs]` à trancher/téléverser.
+ */
+export function computeRealignWindow(clips: WbwTimestampClip[]): RealignWindow {
+	const starts = clips.map((clip) =>
+		Math.round((clip.alignmentMetadata?.timeFrom ?? clip.startTime / 1000) * 1000)
+	);
+	const ends = clips.map((clip) =>
+		Math.round((clip.alignmentMetadata?.timeTo ?? clip.endTime / 1000) * 1000)
+	);
+	return { startMs: Math.min(...starts), endMs: Math.max(...ends) };
+}
+
+/**
  * Calcule les timestamps WBW manquants via l'API du Universal Aligner (`/timestamps_direct`).
  *
  * Indépendant de la segmentation : construit un segment par sous-titre dépourvu de timestamps
- * (quelle que soit la façon dont le projet a été créé), demande l'alignement MFA à partir de
+ * (quelle que soit la façon dont le projet a été créé), demande l'alignement mot à mot à partir de
  * l'audio courant, puis réinjecte les mots dans chaque clip. Réutilise les métadonnées
  * d'alignement existantes quand elles sont présentes, sinon les dérive des références du clip.
  *
@@ -143,33 +177,36 @@ export async function computeMissingWbwTimestamps(): Promise<{ enriched: number;
  *
  * Variante ciblée de {@link computeMissingWbwTimestamps} : permet de (re)calculer les
  * timestamps d'un seul clip (menu contextuel) ou d'un sous-ensemble, sans toucher aux autres.
- * Téléverse l'audio complet (utilisé par les actions manuelles « Générer »/« Calculer »).
+ * Téléverse uniquement la fenêtre audio qui couvre les clips ciblés.
  *
- * @param {SubtitleClip[]} clips Sous-titres dont les timestamps doivent être calculés.
+ * @param {WbwTimestampClip[]} clips Sous-titres dont les timestamps doivent être calculés.
  * @returns {Promise<{ enriched: number; total: number }>} Nombre de clips enrichis et total ciblé.
  */
 export async function computeWbwTimestampsForClips(
-	clips: SubtitleClip[]
+	clips: WbwTimestampClip[]
 ): Promise<{ enriched: number; total: number }> {
-	return computeWbwTimestampsForClipsSliced(clips, {});
+	if (clips.length === 0) return { enriched: 0, total: 0 };
+	return computeWbwTimestampsForClipsSliced(clips, {
+		window: computeRealignWindow(clips)
+	});
 }
 
 /**
  * Cœur du calcul WBW, avec tranche audio optionnelle et garde « dernier gagne ».
  *
  * Quand une fenêtre est fournie, seul l'audio `[startMs, endMs]` est téléversé et les temps des
- * segments envoyés à MFA sont recalés sur l'origine de la fenêtre ; les temps ABSOLUS (timeline)
+ * segments envoyés au service sont recalés sur l'origine de la fenêtre ; les temps ABSOLUS (timeline)
  * restent écrits dans `alignmentMetadata`. Les mots renvoyés sont relatifs au segment, donc le
  * recalage sur la durée du clip est inchangé.
  *
- * @param {SubtitleClip[]} clips Sous-titres à (re)calculer.
- * @param {{ window?: RealignWindow; shouldCommit?: (clip: SubtitleClip) => boolean }} opts Options
+ * @param {WbwTimestampClip[]} clips Sous-titres à (re)calculer.
+ * @param {{ window?: RealignWindow; shouldCommit?: (clip: WbwTimestampClip) => boolean }} opts Options
  *   de tranche et garde « dernier gagne » par clip.
  * @returns {Promise<{ enriched: number; total: number }>} Nombre de clips enrichis et total ciblé.
  */
 export async function computeWbwTimestampsForClipsSliced(
-	clips: SubtitleClip[],
-	opts: { window?: RealignWindow; shouldCommit?: (clip: SubtitleClip) => boolean }
+	clips: WbwTimestampClip[],
+	opts: { window?: RealignWindow; shouldCommit?: (clip: WbwTimestampClip) => boolean }
 ): Promise<{ enriched: number; total: number }> {
 	if (clips.length === 0) return { enriched: 0, total: 0 };
 
@@ -179,12 +216,24 @@ export async function computeWbwTimestampsForClipsSliced(
 	// Segments aux temps ABSOLUS (timeline) — réutilisés pour écrire les métadonnées.
 	const segments: SegmentationSegment[] = clips.map((clip, index) => {
 		const meta = clip.alignmentMetadata;
+		const specialType =
+			clip instanceof PredefinedSubtitleClip ? clip.predefinedSubtitleType : meta?.specialType;
+		const refFrom =
+			meta?.refFrom ||
+			(clip instanceof PredefinedSubtitleClip
+				? specialType
+				: `${clip.surah}:${clip.verse}:${clip.startWordIndex + 1}`);
+		const refTo =
+			meta?.refTo ||
+			(clip instanceof PredefinedSubtitleClip
+				? specialType
+				: `${clip.surah}:${clip.verse}:${clip.endWordIndex + 1}`);
 		return {
 			segment: meta?.segment ?? index,
-			ref_from: meta?.refFrom || `${clip.surah}:${clip.verse}:${clip.startWordIndex + 1}`,
-			ref_to: meta?.refTo || `${clip.surah}:${clip.verse}:${clip.endWordIndex + 1}`,
+			ref_from: refFrom,
+			ref_to: refTo,
 			matched_text: meta?.matchedText ?? clip.text,
-			special_type: meta?.specialType,
+			special_type: specialType,
 			time_from: meta?.timeFrom ?? clip.startTime / 1000,
 			time_to: meta?.timeTo ?? clip.endTime / 1000,
 			words: []
@@ -207,31 +256,35 @@ export async function computeWbwTimestampsForClipsSliced(
 	const enrichedSegments = response.segments ?? [];
 
 	let enriched = 0;
-	clips.forEach((clip, index) => {
-		const words = enrichedSegments[index]?.words ?? [];
-		if (words.length === 0) return;
-		// « Dernier gagne » par clip : on n'écrase pas un clip réédité depuis le début de l'appel.
-		if (opts.shouldCommit && !opts.shouldCommit(clip)) return;
+	ProjectHistoryManager.track('compute wbw timestamps', () => {
+		clips.forEach((clip, index) => {
+			const words = enrichedSegments[index]?.words ?? [];
+			if (words.length === 0) return;
+			// « Dernier gagne » par clip : on n'écrase pas un clip réédité depuis le début de l'appel.
+			if (opts.shouldCommit && !opts.shouldCommit(clip)) return;
 
-		// Recale les mots sur la durée du clip, comme lors de l'application d'une segmentation.
-		const clipDurationS = (clip.endTime - clip.startTime) / 1000;
-		const clampedWords = words.map((word, position, arr) => ({
-			...word,
-			start: position === 0 ? 0 : Math.max(0, Math.min(clipDurationS, word.start)),
-			end:
-				position === arr.length - 1 ? clipDurationS : Math.max(0, Math.min(clipDurationS, word.end))
-		}));
+			// Recale les mots sur la durée du clip, comme lors de l'application d'une segmentation.
+			const clipDurationS = (clip.endTime - clip.startTime) / 1000;
+			const clampedWords = words.map((word, position, arr) => ({
+				...word,
+				start: position === 0 ? 0 : Math.max(0, Math.min(clipDurationS, word.start)),
+				end:
+					position === arr.length - 1
+						? clipDurationS
+						: Math.max(0, Math.min(clipDurationS, word.end))
+			}));
 
-		const metadata = buildSubtitleAlignmentMetadata(
-			clip.alignmentMetadata?.source ?? 'api',
-			segments[index],
-			clampedWords
-		);
-		if (metadata) {
-			clip.alignmentMetadata = metadata;
-			clip.needsWbwTimestampReview = false;
-			enriched += 1;
-		}
+			const metadata = buildSubtitleAlignmentMetadata(
+				clip.alignmentMetadata?.source ?? 'api',
+				segments[index],
+				clampedWords
+			);
+			if (metadata) {
+				clip.alignmentMetadata = metadata;
+				clip.needsWbwTimestampReview = false;
+				enriched += 1;
+			}
+		});
 	});
 
 	if (enriched > 0) refreshSegmentationContextFromTrack(true);


### PR DESCRIPTION
Timestamp requests now upload only the smallest audio window covering their target clips. Basmala and Isti'adha are included in bulk and per-clip timestamp generation using their canonical special references.