### PR TITLE
Fix large-surah downloads: reliability, progress, apply speed, and shared audio cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules
 .netlify
 .wrangler
 /.svelte-kit
+# Nested .svelte-kit dirs generated when svelte-check runs from a subfolder.
+.svelte-kit/
 /build
 
 # OS

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -179,7 +179,7 @@ pub fn save_file(location: String, content: String) -> Result<(), String> {
 
 /// Télécharge un fichier HTTP puis l'écrit de manière asynchrone sur disque.
 #[tauri::command]
-pub async fn download_file(url: String, path: String) -> Result<(), String> {
+pub async fn download_file(url: String, path: String) -> Result<u64, String> {
     let path_buf = path_utils::normalize_output_path(&path);
     if let Some(parent) = path_buf.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
@@ -190,13 +190,19 @@ pub async fn download_file(url: String, path: String) -> Result<(), String> {
     let temp_path = std::path::PathBuf::from(temp_os);
     let _ = tokio::fs::remove_file(&temp_path).await;
 
+    // Pas de timeout total : les longues sourates (>100 Mo) peuvent dépasser
+    // n'importe quelle limite fixe sur une connexion lente. On borne uniquement
+    // le temps d'inactivité entre deux lectures pour couper une connexion morte
+    // sans jamais tuer un téléchargement qui progresse encore.
     let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(15))
-        .timeout(Duration::from_secs(15 * 60))
+        .read_timeout(Duration::from_secs(120))
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
 
-    let max_retries = 3usize;
+    // 5 essais : laisse la place à un fallback « reprise Range échouée →
+    // repart d'un GET complet » sans épuiser les tentatives.
+    let max_retries = 5usize;
     let mut downloaded = 0u64;
     let mut last_error = String::new();
 
@@ -229,6 +235,13 @@ pub async fn download_file(url: String, path: String) -> Result<(), String> {
                 max_retries,
                 response.status()
             );
+            // Certains hôtes (miroirs MP3Quran) rejettent une requête Range
+            // ouverte (`bytes=N-`) avec 400/416. Dans ce cas on abandonne la
+            // reprise partielle et on repart d'un GET complet à l'essai suivant.
+            if downloaded > 0 {
+                downloaded = 0;
+                let _ = tokio::fs::remove_file(&temp_path).await;
+            }
             continue;
         }
 
@@ -284,7 +297,7 @@ pub async fn download_file(url: String, path: String) -> Result<(), String> {
             tokio::fs::rename(&temp_path, &path_buf)
                 .await
                 .map_err(|e| format!("Failed to finalize file: {}", e))?;
-            return Ok(());
+            return Ok(downloaded);
         }
     }
 

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::io::{BufReader, BufWriter, Read, Write};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use reqwest::header::{ACCEPT, ACCEPT_ENCODING, RANGE, USER_AGENT};
+use reqwest::header::{ACCEPT, ACCEPT_ENCODING, CONTENT_RANGE, RANGE, USER_AGENT};
 use tokio::io::AsyncWriteExt;
 
 use crate::path_utils;
@@ -179,7 +179,12 @@ pub fn save_file(location: String, content: String) -> Result<(), String> {
 
 /// Télécharge un fichier HTTP puis l'écrit de manière asynchrone sur disque.
 #[tauri::command]
-pub async fn download_file(url: String, path: String) -> Result<u64, String> {
+pub async fn download_file(
+    url: String,
+    path: String,
+    app_handle: tauri::AppHandle,
+    download_id: Option<String>,
+) -> Result<u64, String> {
     let path_buf = path_utils::normalize_output_path(&path);
     if let Some(parent) = path_buf.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
@@ -205,6 +210,24 @@ pub async fn download_file(url: String, path: String) -> Result<u64, String> {
     let max_retries = 5usize;
     let mut downloaded = 0u64;
     let mut last_error = String::new();
+
+    // Progression : émise seulement si le caller fournit un `download_id`.
+    // `total` reste None quand l'hôte ne renvoie pas de Content-Length (ex. le
+    // proxy audio du space, transcodé à la volée) → l'UI affiche alors les Mo
+    // téléchargés sans pourcentage.
+    let mut total: Option<u64> = None;
+    let emit_progress = |downloaded: u64, total: Option<u64>| {
+        if let Some(id) = download_id.as_deref() {
+            let _ = app_handle.emit(
+                "download-progress",
+                serde_json::json!({
+                    "downloadId": id,
+                    "downloaded": downloaded,
+                    "total": total,
+                }),
+            );
+        }
+    };
 
     for attempt in 1..=max_retries {
         let mut request = client
@@ -249,6 +272,22 @@ pub async fn download_file(url: String, path: String) -> Result<u64, String> {
             downloaded = 0;
         }
 
+        // Taille totale : Content-Length sur un 200 complet, ou le total après
+        // le `/` d'un Content-Range sur une reprise 206. Absente sinon.
+        if total.is_none() {
+            total = if response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+                response
+                    .headers()
+                    .get(CONTENT_RANGE)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| value.rsplit('/').next())
+                    .and_then(|value| value.trim().parse::<u64>().ok())
+            } else {
+                response.content_length().map(|len| downloaded + len)
+            };
+        }
+        emit_progress(downloaded, total);
+
         let mut file = if downloaded == 0 {
             tokio::fs::OpenOptions::new()
                 .create(true)
@@ -268,6 +307,7 @@ pub async fn download_file(url: String, path: String) -> Result<u64, String> {
 
         let mut response = response;
         let mut request_completed = false;
+        let mut last_emit = Instant::now();
         loop {
             match response.chunk().await {
                 Ok(Some(chunk)) => {
@@ -275,11 +315,17 @@ pub async fn download_file(url: String, path: String) -> Result<u64, String> {
                         .await
                         .map_err(|e| format!("Failed to write file: {}", e))?;
                     downloaded += chunk.len() as u64;
+                    // Throttle : au plus ~5 events/s pour ne pas noyer le front.
+                    if last_emit.elapsed() >= Duration::from_millis(200) {
+                        emit_progress(downloaded, total);
+                        last_emit = Instant::now();
+                    }
                 }
                 Ok(None) => {
                     file.flush()
                         .await
                         .map_err(|e| format!("Failed to flush file: {}", e))?;
+                    emit_progress(downloaded, total.or(Some(downloaded)));
                     request_completed = true;
                     break;
                 }

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadButton.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadButton.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+	import { bytesToMb, type DownloadProgress } from '$lib/services/DownloadWithProgress';
+
+	/**
+	 * Bouton de téléchargement avec progression intégrée et géométrie stable.
+	 *
+	 * La progression vit DANS le bouton (barre de remplissage + lecture en chiffres
+	 * tabulaires), pas dans un toast flottant qui se redimensionne : la largeur du
+	 * texte ne bouge plus, donc plus de saut de ligne à chaque octet. Quand la taille
+	 * totale est inconnue (proxy transcodé sans Content-Length), on bascule sur une
+	 * bande indéterminée + les Mo téléchargés.
+	 */
+	let {
+		idleLabel,
+		busyLabel,
+		busy,
+		disabled,
+		progress = null,
+		onclick
+	}: {
+		idleLabel: string;
+		busyLabel: string;
+		busy: boolean;
+		disabled: boolean;
+		progress?: DownloadProgress | null;
+		onclick: () => void;
+	} = $props();
+
+	const percent = $derived(
+		progress && progress.total && progress.total > 0
+			? Math.min(100, Math.round((progress.downloaded / progress.total) * 100))
+			: null
+	);
+
+	// Lecture de droite : pourcentage si la taille est connue, sinon Mo transférés.
+	const readout = $derived.by(() => {
+		if (!busy || !progress || progress.downloaded <= 0) return null;
+		return percent !== null ? `${percent}%` : `${bytesToMb(progress.downloaded)} MB`;
+	});
+
+	const indeterminate = $derived(busy && percent === null);
+</script>
+
+<button
+	class="download-btn btn-accent"
+	type="button"
+	{onclick}
+	{disabled}
+	aria-busy={busy}
+>
+	{#if busy && percent !== null}
+		<span class="download-btn__fill" style="width: {percent}%"></span>
+	{:else if indeterminate}
+		<span class="download-btn__fill download-btn__fill--indeterminate"></span>
+	{/if}
+
+	<span class="download-btn__content">
+		{#if busy}
+			<span class="material-icons download-btn__spinner">sync</span>
+			<span class="download-btn__label">{busyLabel}</span>
+			{#if readout}
+				<span class="download-btn__readout">{readout}</span>
+			{/if}
+		{:else}
+			<span class="material-icons text-lg">download</span>
+			<span class="download-btn__label">{idleLabel}</span>
+		{/if}
+	</span>
+</button>
+
+<style>
+	.download-btn {
+		position: relative;
+		isolation: isolate;
+		overflow: hidden;
+		width: 100%;
+		padding: 0.75rem 1rem;
+		border-radius: 0.5rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		box-shadow: var(--shadow-lg, 0 10px 15px -3px rgb(0 0 0 / 0.15));
+		transition: scale 200ms cubic-bezier(0.22, 1, 0.36, 1);
+	}
+
+	.download-btn:hover:not(:disabled) {
+		scale: 1.02;
+	}
+
+	.download-btn:disabled {
+		cursor: not-allowed;
+	}
+
+	/* Opacité réduite seulement quand rien ne se passe : pendant un download le
+	   bouton est disabled mais doit rester bien lisible pour montrer l'avancée. */
+	.download-btn:disabled:not([aria-busy='true']) {
+		opacity: 0.5;
+	}
+
+	.download-btn__fill {
+		position: absolute;
+		inset: 0 auto 0 0;
+		z-index: -1;
+		background: rgb(255 255 255 / 0.22);
+		transition: width 250ms cubic-bezier(0.22, 1, 0.36, 1);
+	}
+
+	.download-btn__fill--indeterminate {
+		width: 40%;
+		background: linear-gradient(
+			90deg,
+			transparent 0%,
+			rgb(255 255 255 / 0.28) 50%,
+			transparent 100%
+		);
+		animation: download-btn-slide 1.15s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+	}
+
+	@keyframes download-btn-slide {
+		from {
+			transform: translateX(-100%);
+		}
+		to {
+			transform: translateX(350%);
+		}
+	}
+
+	.download-btn__content {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+
+	.download-btn__label {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.download-btn__spinner {
+		font-size: 1.125rem;
+		animation: download-btn-spin 1s linear infinite;
+	}
+
+	@keyframes download-btn-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	/* Chiffres tabulaires + largeur plancher : la lecture ne « respire » pas quand
+	   le nombre passe de 9% à 10% ou de 9.9 à 10.0 Mo. */
+	.download-btn__readout {
+		flex: none;
+		min-width: 4ch;
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+		font-feature-settings: 'tnum' 1;
+		opacity: 0.85;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.download-btn,
+		.download-btn__fill {
+			transition: none;
+		}
+		.download-btn__fill--indeterminate {
+			animation: none;
+			width: 100%;
+			opacity: 0.5;
+		}
+		.download-btn__spinner {
+			animation-duration: 2.4s;
+		}
+	}
+</style>

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranSourceSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranSourceSection.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import toast from 'svelte-5-french-toast';
-	import { invoke } from '@tauri-apps/api/core';
 	import { join } from '@tauri-apps/api/path';
 	import { onMount } from 'svelte';
 	import LL from '$lib/i18n/i18n-svelte';
@@ -14,6 +13,11 @@
 	import { AnalyticsService } from '$lib/services/AnalyticsService';
 	import { runNativeSegmentation } from '$lib/services/AutoSegmentation';
 	import {
+		bytesToMb,
+		downloadFileWithProgress,
+		type DownloadProgress
+	} from '$lib/services/DownloadWithProgress';
+	import {
 		Mp3QuranService,
 		type Mp3QuranReciter,
 		type TimingReciter
@@ -21,6 +25,7 @@
 	import { ProjectService } from '$lib/services/ProjectService';
 	import { QdcRecitationService, type QdcRecitation } from '$lib/services/QdcRecitationService';
 	import QuranSourceTabs from './QuranSourceTabs.svelte';
+	import DownloadButton from './DownloadButton.svelte';
 
 	type DownloadOption = {
 		source: 'mp3quran' | 'qdc';
@@ -46,6 +51,8 @@
 	let selectedSurahId = $state(-1);
 	let isLoadingReciters = $state(true);
 	let isDownloading = $state(false);
+	// Progression du téléchargement, affichée dans le bouton (pas de chiffre en toast).
+	let downloadProgress = $state<DownloadProgress | null>(null);
 	// Quran.com est l'onglet par défaut comme demandé.
 	let selectedSource = $state<'qdc' | 'mp3quran'>('qdc');
 
@@ -177,12 +184,11 @@
 			const downloadPath = await ProjectService.getAssetFolderForProject(
 				globalState.currentProject!.detail.id
 			);
-			toastId = toast.loading(
-				get(LL).editor.downloadingSurah({
-					surah: surahName.split('.')[1].trim(),
-					reciter: selectedOption.reciterName
-				})
-			);
+			const downloadingLabel = get(LL).editor.downloadingSurah({
+				surah: surahName.split('.')[1].trim(),
+				reciter: selectedOption.reciterName
+			});
+			toastId = toast.loading(downloadingLabel);
 
 			const fullPath = await join(downloadPath, fileName);
 
@@ -238,16 +244,18 @@
 				};
 			}
 
-			const downloadedBytes = (await invoke('download_file', {
-				url: audioUrl,
-				path: fullPath
-			})) as number;
+			downloadProgress = null;
+			const downloadedBytes = await downloadFileWithProgress(audioUrl, fullPath, (progress) => {
+				downloadProgress = progress;
+			});
+			downloadProgress = null;
 
 			const projectContent = globalState.currentProject!.content;
 			projectContent.addAsset(fullPath, audioUrl, sourceType, metadata);
 
-			const sizeMb = (downloadedBytes / (1024 * 1024)).toFixed(1);
-			toast.success(`${get(LL).editor.downloadSuccessful()} (${sizeMb} MB)`, { id: toastId });
+			toast.success(`${get(LL).editor.downloadSuccessful()} (${bytesToMb(downloadedBytes)} MB)`, {
+				id: toastId
+			});
 
 			if (selectedOption.supportsNativeTiming) {
 				// On retrouve l'asset fraîchement ajouté pour l'insérer dans la timeline si l'utilisateur accepte.
@@ -286,6 +294,7 @@
 			});
 		} finally {
 			isDownloading = false;
+			downloadProgress = null;
 		}
 	}
 </script>
@@ -349,19 +358,13 @@
 			</select>
 		</div>
 
-		<button
-			class="w-full btn-accent flex items-center justify-center gap-2 py-3 px-4 rounded-lg text-sm font-medium transition-all duration-200 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 shadow-lg hover:shadow-xl relative overflow-hidden"
-			type="button"
-			onclick={downloadAsset}
+		<DownloadButton
+			idleLabel={get(LL).editor.downloadAudio()}
+			busyLabel={get(LL).editor.downloadingLabel()}
+			busy={isDownloading}
 			disabled={selectedOptionIndex === -1 || selectedSurahId === -1 || isDownloading}
-		>
-			{#if isDownloading}
-				<span class="material-icons animate-spin text-lg">sync</span>
-				<span>{get(LL).editor.downloadingLabel()}</span>
-			{:else}
-				<span class="material-icons text-lg">download</span>
-				<span>{get(LL).editor.downloadAudio()}</span>
-			{/if}
-		</button>
+			progress={downloadProgress}
+			onclick={downloadAsset}
+		/>
 	</div>
 </Section>

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranSourceSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranSourceSection.svelte
@@ -238,15 +238,16 @@
 				};
 			}
 
-			await invoke('download_file', {
+			const downloadedBytes = (await invoke('download_file', {
 				url: audioUrl,
 				path: fullPath
-			});
+			})) as number;
 
 			const projectContent = globalState.currentProject!.content;
 			projectContent.addAsset(fullPath, audioUrl, sourceType, metadata);
 
-			toast.success(get(LL).editor.downloadSuccessful(), { id: toastId });
+			const sizeMb = (downloadedBytes / (1024 * 1024)).toFixed(1);
+			toast.success(`${get(LL).editor.downloadSuccessful()} (${sizeMb} MB)`, { id: toastId });
 
 			if (selectedOption.supportsNativeTiming) {
 				// On retrouve l'asset fraîchement ajouté pour l'insérer dans la timeline si l'utilisateur accepte.

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranSourceSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranSourceSection.svelte
@@ -6,17 +6,20 @@
 	import { get } from 'svelte/store';
 
 	import { SourceType } from '$lib/classes';
+	import type { Project } from '$lib/classes';
 	import { Quran } from '$lib/classes/Quran';
 	import Section from '$lib/components/projectEditor/Section.svelte';
 	import ModalManager from '$lib/components/modals/ModalManager';
 	import { globalState } from '$lib/runes/main.svelte';
 	import { AnalyticsService } from '$lib/services/AnalyticsService';
 	import { runNativeSegmentation } from '$lib/services/AutoSegmentation';
+	import { bytesToMb, downloadFileWithProgress } from '$lib/services/DownloadWithProgress';
 	import {
-		bytesToMb,
-		downloadFileWithProgress,
-		type DownloadProgress
-	} from '$lib/services/DownloadWithProgress';
+		getAudioDownload,
+		runAudioDownload,
+		type AudioDownloadContext,
+		type AudioDownloadDone
+	} from '$lib/services/AudioDownloadStore.svelte';
 	import {
 		Mp3QuranService,
 		type Mp3QuranReciter,
@@ -50,9 +53,12 @@
 	let selectedOptionIndex = $state(-1);
 	let selectedSurahId = $state(-1);
 	let isLoadingReciters = $state(true);
-	let isDownloading = $state(false);
-	// Progression du téléchargement, affichée dans le bouton (pas de chiffre en toast).
-	let downloadProgress = $state<DownloadProgress | null>(null);
+
+	// État de téléchargement hébergé hors composant (store de module) : survit au
+	// démontage du Video Editor lors d'une bascule d'onglet/fenêtre dans QC.
+	const projectId = $derived(globalState.currentProject?.detail.id ?? -1);
+	const download = $derived(getAudioDownload(projectId, 'quranSource'));
+	const isDownloading = $derived(download.busy);
 	// Quran.com est l'onglet par défaut comme demandé.
 	let selectedSource = $state<'qdc' | 'mp3quran'>('qdc');
 
@@ -158,144 +164,165 @@
 		selectedSurahId = -1;
 	});
 
-	/**
-	 * Télécharge l'audio depuis la source active, ajoute l'asset au projet,
-	 * puis propose de charger les timings natifs si la source les fournit.
-	 */
-	async function downloadAsset(): Promise<void> {
-		if (selectedOptionIndex === -1 || selectedSurahId === -1) return;
+	/** Sélection figée au lancement du téléchargement (détachée des `$state` réactifs). */
+	type QuranSourceSelection = {
+		option: DownloadOption;
+		surahId: number;
+		surahName: string;
+		fileName: string;
+		formattedSurahId: string;
+	};
 
-		isDownloading = true;
-		const selectedOption = filteredDownloadOptions[selectedOptionIndex];
+	/**
+	 * Télécharge l'audio depuis la source active vers le dossier du projet ciblé, ajoute
+	 * l'asset, puis propose de charger les timings natifs si la source les fournit.
+	 *
+	 * `project` est capturé au lancement : le travail est détaché du composant, donc on
+	 * ne relit jamais `globalState.currentProject`.
+	 */
+	async function runQuranSourceDownload(
+		project: Project,
+		ctx: AudioDownloadContext,
+		sel: QuranSourceSelection
+	): Promise<AudioDownloadDone> {
+		const { option, surahId, surahName, fileName, formattedSurahId } = sel;
+		const downloadPath = await ProjectService.getAssetFolderForProject(project.detail.id);
+		const fullPath = await join(downloadPath, fileName);
+
+		let audioUrl = '';
+		let sourceType = SourceType.Mp3Quran;
+		let metadata: Record<string, unknown> = {};
+
+		if (option.source === 'mp3quran') {
+			// MP3Quran expose directement l'URL finale du mp3 par convention de dossier.
+			audioUrl = `${option.mp3Server}${formattedSurahId}.mp3`;
+			sourceType = SourceType.Mp3Quran;
+			if (option.supportsNativeTiming) {
+				metadata = {
+					mp3Quran: {
+						reciterId: option.mp3ReciterId,
+						moshafId: option.mp3MoshafId,
+						surahId
+					},
+					nativeTiming: {
+						provider: 'mp3quran',
+						reciterId: option.mp3ReciterId,
+						moshafId: option.mp3MoshafId,
+						surahId
+					}
+				};
+			}
+		} else {
+			// Pour QDC, on passe d'abord par le proxy Quran Caption pour ne pas exposer les clés.
+			const chapterAudio = await QdcRecitationService.getChapterAudio(
+				option.qdcRecitationId!,
+				surahId
+			);
+			if (!chapterAudio?.audio_url) {
+				throw new Error('Unable to fetch Quran.com audio URL for this recitation.');
+			}
+			// Certains audios QDC sont listés mais absents côté CDN. On le vérifie avant download.
+			const isAudioAvailable = await QdcRecitationService.isAudioUrlAvailable(
+				chapterAudio.audio_url
+			);
+			if (!isAudioAvailable) {
+				throw new Error(
+					'This Quran.com recitation is listed, but the source audio file is unavailable upstream for this surah.'
+				);
+			}
+			audioUrl = chapterAudio.audio_url;
+			sourceType = SourceType.QuranFoundation;
+			metadata = {
+				nativeTiming: {
+					provider: 'qdc',
+					recitationId: option.qdcRecitationId,
+					surahId
+				}
+			};
+		}
+
+		const downloadedBytes = await downloadFileWithProgress(audioUrl, fullPath, ctx.report);
+		ctx.report(null);
+
+		const projectContent = project.content;
+		projectContent.addAsset(fullPath, audioUrl, sourceType, metadata);
+
+		// Timings natifs optionnels : on ne les propose/applique que si le projet ciblé
+		// est toujours ouvert (la confirmation + segmentation lisent l'état global).
+		if (option.supportsNativeTiming && globalState.currentProject?.detail.id === project.detail.id) {
+			const normalizedFullPath = fullPath.replace(/\\/g, '/').replace(/\/+/g, '/');
+			const addedAsset = projectContent.assets.find(
+				(asset) => asset.filePath === normalizedFullPath
+			);
+
+			if (addedAsset) {
+				const confirmTimingLoad = await ModalManager.confirmModal(
+					get(LL).editor.nativeTimingsConfirm(),
+					true
+				);
+
+				if (confirmTimingLoad) {
+					await addedAsset.addToTimeline(false, true);
+					await runNativeSegmentation(addedAsset.id);
+				}
+			}
+		}
+
+		if (option.source === 'mp3quran') {
+			AnalyticsService.downloadFromMP3Quran(option.reciterName, surahName, fileName);
+		}
+		AnalyticsService.downloadRecitationAudio(
+			option.sourceLabel,
+			option.reciterName,
+			surahName,
+			fileName
+		);
+
+		return {
+			title: get(LL).editor.downloadSuccessful(),
+			body: `${surahName} · ${bytesToMb(downloadedBytes)} MB`
+		};
+	}
+
+	/**
+	 * Point d'entrée du bouton. Fige la sélection et le projet ciblé, puis délègue au
+	 * store de téléchargement (détaché du composant) : la bascule d'onglet/fenêtre dans
+	 * QC n'interrompt plus le téléchargement, et une notification annonce la fin.
+	 */
+	function onDownload(): void {
+		const project = globalState.currentProject;
+		if (!project || selectedOptionIndex === -1 || selectedSurahId === -1 || isDownloading) return;
+
+		const option = filteredDownloadOptions[selectedOptionIndex];
 		const formattedSurahId = selectedSurahId.toString().padStart(3, '0');
 		const surahName =
 			availableSurahs.find((surah) => surah.id === selectedSurahId)?.name.split(' (')[0] ??
 			`Surah ${formattedSurahId}`;
-		const rawBaseName = `${selectedOption.reciterName} - ${surahName}`;
+		const rawBaseName = `${option.reciterName} - ${surahName}`;
 		let sanitizedBaseName = rawBaseName.replace(/[<>:"/\\|?*]/g, '').trim();
 		if (!sanitizedBaseName) {
 			sanitizedBaseName = `surah-${formattedSurahId}`;
 		}
 		const fileName = `${sanitizedBaseName}.mp3`;
 
-		let toastId: string | undefined;
+		const sel: QuranSourceSelection = {
+			option,
+			surahId: selectedSurahId,
+			surahName,
+			fileName,
+			formattedSurahId
+		};
 
-		try {
-			const downloadPath = await ProjectService.getAssetFolderForProject(
-				globalState.currentProject!.detail.id
-			);
-			const downloadingLabel = get(LL).editor.downloadingSurah({
-				surah: surahName.split('.')[1].trim(),
-				reciter: selectedOption.reciterName
-			});
-			toastId = toast.loading(downloadingLabel);
-
-			const fullPath = await join(downloadPath, fileName);
-
-			let audioUrl = '';
-			let sourceType = SourceType.Mp3Quran;
-			let metadata: Record<string, unknown> = {};
-
-			if (selectedOption.source === 'mp3quran') {
-				// MP3Quran expose directement l'URL finale du mp3 par convention de dossier.
-				audioUrl = `${selectedOption.mp3Server}${formattedSurahId}.mp3`;
-				sourceType = SourceType.Mp3Quran;
-				if (selectedOption.supportsNativeTiming) {
-					metadata = {
-						mp3Quran: {
-							reciterId: selectedOption.mp3ReciterId,
-							moshafId: selectedOption.mp3MoshafId,
-							surahId: selectedSurahId
-						},
-						nativeTiming: {
-							provider: 'mp3quran',
-							reciterId: selectedOption.mp3ReciterId,
-							moshafId: selectedOption.mp3MoshafId,
-							surahId: selectedSurahId
-						}
-					};
-				}
-			} else {
-				// Pour QDC, on passe d'abord par le proxy Quran Caption pour ne pas exposer les clés.
-				const chapterAudio = await QdcRecitationService.getChapterAudio(
-					selectedOption.qdcRecitationId!,
-					selectedSurahId
-				);
-				if (!chapterAudio?.audio_url) {
-					throw new Error('Unable to fetch Quran.com audio URL for this recitation.');
-				}
-				// Certains audios QDC sont listés mais absents côté CDN. On le vérifie avant download.
-				const isAudioAvailable = await QdcRecitationService.isAudioUrlAvailable(
-					chapterAudio.audio_url
-				);
-				if (!isAudioAvailable) {
-					throw new Error(
-						'This Quran.com recitation is listed, but the source audio file is unavailable upstream for this surah.'
-					);
-				}
-				audioUrl = chapterAudio.audio_url;
-				sourceType = SourceType.QuranFoundation;
-				metadata = {
-					nativeTiming: {
-						provider: 'qdc',
-						recitationId: selectedOption.qdcRecitationId,
-						surahId: selectedSurahId
-					}
-				};
-			}
-
-			downloadProgress = null;
-			const downloadedBytes = await downloadFileWithProgress(audioUrl, fullPath, (progress) => {
-				downloadProgress = progress;
-			});
-			downloadProgress = null;
-
-			const projectContent = globalState.currentProject!.content;
-			projectContent.addAsset(fullPath, audioUrl, sourceType, metadata);
-
-			toast.success(`${get(LL).editor.downloadSuccessful()} (${bytesToMb(downloadedBytes)} MB)`, {
-				id: toastId
-			});
-
-			if (selectedOption.supportsNativeTiming) {
-				// On retrouve l'asset fraîchement ajouté pour l'insérer dans la timeline si l'utilisateur accepte.
-				const normalizedFullPath = fullPath.replace(/\\/g, '/').replace(/\/+/g, '/');
-				const addedAsset = projectContent.assets.find(
-					(asset) => asset.filePath === normalizedFullPath
-				);
-
-				if (addedAsset) {
-					const confirmTimingLoad = await ModalManager.confirmModal(
-						get(LL).editor.nativeTimingsConfirm(),
-						true
-					);
-
-					if (confirmTimingLoad) {
-						await addedAsset.addToTimeline(false, true);
-						await runNativeSegmentation(addedAsset.id);
-					}
-				}
-			}
-
-			if (selectedOption.source === 'mp3quran') {
-				AnalyticsService.downloadFromMP3Quran(selectedOption.reciterName, surahName, fileName);
-			}
-			AnalyticsService.downloadRecitationAudio(
-				selectedOption.sourceLabel,
-				selectedOption.reciterName,
-				surahName,
-				fileName
-			);
-		} catch (error) {
-			console.error('Download error:', error);
-			toast.error(get(LL).editor.errorDownloading({ error: String(error) }), {
-				id: toastId,
-				duration: 5000
-			});
-		} finally {
-			isDownloading = false;
-			downloadProgress = null;
-		}
+		void runAudioDownload({
+			projectId: project.detail.id,
+			section: 'quranSource',
+			label: get(LL).editor.downloadingSurah({
+				surah: surahName.split('.')[1]?.trim() ?? surahName,
+				reciter: option.reciterName
+			}),
+			errorTitle: get(LL).editor.downloadFailed(),
+			run: (ctx) => runQuranSourceDownload(project, ctx, sel)
+		});
 	}
 </script>
 
@@ -360,11 +387,11 @@
 
 		<DownloadButton
 			idleLabel={get(LL).editor.downloadAudio()}
-			busyLabel={get(LL).editor.downloadingLabel()}
+			busyLabel={download.label || get(LL).editor.downloadingLabel()}
 			busy={isDownloading}
 			disabled={selectedOptionIndex === -1 || selectedSurahId === -1 || isDownloading}
-			progress={downloadProgress}
-			onclick={downloadAsset}
+			progress={download.progress}
+			onclick={onDownload}
 		/>
 	</div>
 </Section>

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
@@ -12,12 +12,15 @@
 	import SearchableSelect from '$lib/components/misc/SearchableSelect.svelte';
 	import DownloadButton from './DownloadButton.svelte';
 	import { globalState } from '$lib/runes/main.svelte';
+	import type { Project } from '$lib/classes';
 	import { applyPreloadSegmentsToProject } from '$lib/services/AutoSegmentation';
+	import { bytesToMb, downloadFileWithProgress } from '$lib/services/DownloadWithProgress';
 	import {
-		bytesToMb,
-		downloadFileWithProgress,
-		type DownloadProgress
-	} from '$lib/services/DownloadWithProgress';
+		getAudioDownload,
+		runAudioDownload,
+		type AudioDownloadContext,
+		type AudioDownloadDone
+	} from '$lib/services/AudioDownloadStore.svelte';
 	import { quaCacheRelKey, resolveQuaCachePath } from '$lib/services/QuaAudioCache';
 	import {
 		QuranicUniversalAudioService,
@@ -38,10 +41,13 @@
 	let ayahFrom = $state(1);
 	let ayahTo = $state(1);
 	let isLoadingRecitations = $state(true);
-	let isDownloading = $state(false);
-	// Progression + libellé de phase pilotant le bouton (aucun chiffre dans les toasts).
-	let downloadProgress = $state<DownloadProgress | null>(null);
-	let busyLabel = $state('');
+
+	// État de téléchargement hébergé hors composant (store de module) : survit au
+	// démontage du Video Editor lors d'une bascule d'onglet/fenêtre dans QC, donc
+	// le bouton retrouve sa progression et son état occupé au remontage.
+	const projectId = $derived(globalState.currentProject?.detail.id ?? -1);
+	const download = $derived(getAudioDownload(projectId, 'qua'));
+	const isDownloading = $derived(download.busy);
 
 	// Options de segmentation (reprend les défauts de l'assistant auto-segmentation).
 	// Les timestamps mot à mot sont toujours fournis par le Preload → case forcée/désactivée.
@@ -159,78 +165,85 @@
 
 	/**
 	 * Télécharge le mp3 du chapitre (ou le réutilise depuis le cache partagé QUA),
-	 * l'ajoute comme asset puis le pose sur la piste audio. `cacheKey` identifie de
-	 * façon déterministe l'audio (récitateur + sourate + plage) : un fichier déjà
-	 * présent est réutilisé tel quel, sans re-téléchargement ni copie par projet —
-	 * l'`Asset.filePath` pointe directement sur le fichier du cache. Gère les toasts
-	 * de progression ; relance l'erreur au caller.
+	 * l'ajoute comme asset du projet ciblé puis le pose sur la piste audio. `cacheKey`
+	 * identifie de façon déterministe l'audio (récitateur + sourate + plage) : un
+	 * fichier déjà présent est réutilisé tel quel, sans re-téléchargement ni copie par
+	 * projet — l'`Asset.filePath` pointe directement sur le fichier du cache.
+	 *
+	 * `project` est capturé au lancement : le travail est détaché du composant, donc on
+	 * ne relit jamais `globalState.currentProject` (l'utilisateur peut avoir changé de
+	 * projet entre-temps).
 	 */
 	async function importChapterAudio(
+		project: Project,
+		report: AudioDownloadContext['report'],
 		audioUrl: string,
-		reciterName: string,
-		surahName: string,
 		assetMeta: Record<string, unknown>,
 		cacheKey: string,
 		downloadUrl: string = audioUrl
-	): Promise<void> {
-		const downloadingLabel = get(LL).editor.downloadingSurah({
-			surah: surahName,
-			reciter: reciterName
-		});
-		busyLabel = downloadingLabel;
-		downloadProgress = null;
-		const toastId = toast.loading(downloadingLabel);
-		try {
-			const cachePath = await resolveQuaCachePath(cacheKey);
+	): Promise<{ bytes: number; fromCache: boolean }> {
+		const cachePath = await resolveQuaCachePath(cacheKey);
 
-			// Cache hit → aucun HTTP : on lit juste la taille pour le toast. Sinon on
-			// télécharge la fenêtre audio choisie (`downloadUrl`), en gardant l'URL
-			// serveur d'origine (`audioUrl`) comme provenance de l'asset.
-			let downloadedBytes: number;
-			let fromCache = false;
-			if (await exists(cachePath)) {
-				fromCache = true;
-				downloadedBytes = (await stat(cachePath)).size;
-			} else {
-				downloadedBytes = await downloadFileWithProgress(downloadUrl, cachePath, (progress) => {
-					downloadProgress = progress;
-				});
-			}
-			downloadProgress = null;
-
-			const asset = globalState.currentProject!.content.addAsset(
-				cachePath,
-				audioUrl,
-				SourceType.QuranicUniversalAudio,
-				assetMeta
-			);
-			if (!asset) {
-				throw new Error('Unable to add the downloaded audio as a project asset.');
-			}
-			await asset.ensureDurationLoaded();
-			await asset.addToTimeline(false, true);
-
-			const cachedSuffix = fromCache ? ', cached' : '';
-			toast.success(
-				`${get(LL).editor.downloadSuccessful()} (${bytesToMb(downloadedBytes)} MB${cachedSuffix})`,
-				{ id: toastId }
-			);
-		} catch (error) {
-			toast.dismiss(toastId);
-			throw error;
+		// Cache hit → aucun HTTP : on lit juste la taille. Sinon on télécharge la
+		// fenêtre audio choisie (`downloadUrl`), en gardant l'URL serveur d'origine
+		// (`audioUrl`) comme provenance de l'asset.
+		let bytes: number;
+		let fromCache = false;
+		if (await exists(cachePath)) {
+			fromCache = true;
+			bytes = (await stat(cachePath)).size;
+		} else {
+			bytes = await downloadFileWithProgress(downloadUrl, cachePath, report);
 		}
+		report(null);
+
+		const asset = project.content.addAsset(
+			cachePath,
+			audioUrl,
+			SourceType.QuranicUniversalAudio,
+			assetMeta
+		);
+		if (!asset) {
+			throw new Error('Unable to add the downloaded audio as a project asset.');
+		}
+		await asset.ensureDurationLoaded();
+		await asset.addToTimeline(false, true);
+
+		return { bytes, fromCache };
+	}
+
+	/** Sélection figée au lancement du téléchargement (détachée des `$state` réactifs). */
+	type QuaSelection = {
+		slug: string;
+		surahId: number;
+		surahName: string;
+		from: number;
+		to: number;
+		max: number;
+		fillBySilence: boolean;
+		extendBeforeSilence: boolean;
+		extendBeforeSilenceMs: number;
+	};
+
+	/** Construit le résumé de fin (titre + taille téléchargée) pour la notification. */
+	function downloadDone(surahName: string, bytes: number, fromCache: boolean): AudioDownloadDone {
+		return {
+			title: get(LL).editor.downloadSuccessful(),
+			body: `${surahName} · ${bytesToMb(bytes)} MB${fromCache ? ' (cached)' : ''}`
+		};
 	}
 
 	/** Audio + segments : télécharge le chapitre et applique les segments pré-alignés. */
-	async function downloadAndApply(): Promise<void> {
-		clampAyahRange();
-		const { reciterName, surahName } = currentNames();
-
+	async function downloadAndApply(
+		project: Project,
+		ctx: AudioDownloadContext,
+		sel: QuaSelection
+	): Promise<AudioDownloadDone> {
 		const payload = await QuranicUniversalAudioService.getSegments(
-			selectedSlug,
-			selectedSurahId,
-			ayahFrom,
-			ayahTo
+			sel.slug,
+			sel.surahId,
+			sel.from,
+			sel.to
 		);
 		const audioUrl = payload.audio_url ?? '';
 		if (!audioUrl) {
@@ -245,36 +258,40 @@
 		// fenêtre téléchargée aux frontières « spéciales » de la sourate — isti'adha
 		// /basmala de tête quand le verset 1 est inclus, clôture de fin quand le
 		// dernier verset l'est — puis on réaligne les sous-titres via un décalage.
-		const window = computeAudioWindow(audioUrl);
-		const downloadUrl = window.downloadUrl;
+		const window = computeAudioWindow(audioUrl, sel);
 
-		await importChapterAudio(
+		const { bytes, fromCache } = await importChapterAudio(
+			project,
+			ctx.report,
 			audioUrl,
-			reciterName,
-			surahName,
 			{
 				quranicUniversalAudio: {
-					recitation: selectedSlug,
-					surah: selectedSurahId,
-					verseFrom: ayahFrom,
-					verseTo: ayahTo
+					recitation: sel.slug,
+					surah: sel.surahId,
+					verseFrom: sel.from,
+					verseTo: sel.to
 				}
 			},
 			window.cacheKey,
-			downloadUrl
+			window.downloadUrl
 		);
 
-		// Segments pré-alignés (sans ré-enrichissement MFA). Sur une longue sourate
-		// l'application des clips prend plusieurs secondes : le bouton passe en état
-		// « Applying… » indéterminé (l'UI reste réactive grâce au yield coopératif).
-		busyLabel = 'Applying segments to the timeline…';
-		downloadProgress = null;
-		await applyPreloadSegmentsToProject(payload, {
-			fillBySilence,
-			extendBeforeSilence,
-			extendBeforeSilenceMs,
-			timeOffsetMs: window.timeOffsetMs
-		});
+		// Segments pré-alignés (sans ré-enrichissement MFA). L'application lit
+		// `globalState.currentProject` en interne : on ne l'applique que si le projet
+		// ciblé est toujours ouvert (sinon l'audio est ajouté, sans écraser un autre
+		// projet). Sur une longue sourate l'application prend plusieurs secondes : le
+		// bouton passe en état « Applying… » indéterminé.
+		if (globalState.currentProject?.detail.id === project.detail.id) {
+			ctx.setLabel('Applying segments to the timeline…');
+			await applyPreloadSegmentsToProject(payload, {
+				fillBySilence: sel.fillBySilence,
+				extendBeforeSilence: sel.extendBeforeSilence,
+				extendBeforeSilenceMs: sel.extendBeforeSilenceMs,
+				timeOffsetMs: window.timeOffsetMs
+			});
+		}
+
+		return downloadDone(sel.surahName, bytes, fromCache);
 	}
 
 	/** Borne haute « fin de fichier » : ffmpeg tronque à l'EOF réel (24 h en ms). */
@@ -288,7 +305,10 @@
 	 * @param audioUrl URL de clip renvoyée par le serveur (`?start_ms=&end_ms=`).
 	 * @returns URL à télécharger, clé de cache et décalage temporel des sous-titres.
 	 */
-	function computeAudioWindow(audioUrl: string): {
+	function computeAudioWindow(
+		audioUrl: string,
+		sel: QuaSelection
+	): {
 		downloadUrl: string;
 		cacheKey: string;
 		timeOffsetMs: number;
@@ -298,8 +318,8 @@
 		const origStart = Number.parseInt(params.get('start_ms') ?? '0', 10) || 0;
 		const origEnd = Number.parseInt(params.get('end_ms') ?? '0', 10) || 0;
 
-		const keepIntro = ayahFrom === 1; // le verset 1 amène l'isti'adha/basmala de tête.
-		const keepOutro = ayahTo === maxAyah; // le dernier verset amène la clôture de fin.
+		const keepIntro = sel.from === 1; // le verset 1 amène l'isti'adha/basmala de tête.
+		const keepOutro = sel.to === sel.max; // le dernier verset amène la clôture de fin.
 		const audioStart = keepIntro ? 0 : origStart;
 		const isFullSurah = keepIntro && keepOutro;
 
@@ -310,12 +330,12 @@
 			: `${base}?start_ms=${audioStart}&end_ms=${keepOutro ? AUDIO_END_SENTINEL_MS : origEnd}`;
 
 		const cacheKey = isFullSurah
-			? quaCacheRelKey({ slug: selectedSlug, surah: selectedSurahId })
+			? quaCacheRelKey({ slug: sel.slug, surah: sel.surahId })
 			: quaCacheRelKey({
-					slug: selectedSlug,
-					surah: selectedSurahId,
-					verseFrom: ayahFrom,
-					verseTo: ayahTo
+					slug: sel.slug,
+					surah: sel.surahId,
+					verseFrom: sel.from,
+					verseTo: sel.to
 				});
 
 		// Position d'un segment dans la fenêtre = temps relatif + (origStart − audioStart).
@@ -323,48 +343,68 @@
 	}
 
 	/** Audio seul : télécharge le chapitre complet, sans aucun segment. */
-	async function downloadAudioOnly(): Promise<void> {
-		const { reciterName, surahName } = currentNames();
-
-		const payload = await QuranicUniversalAudioService.getAudioUrl(selectedSlug, selectedSurahId);
+	async function downloadAudioOnly(
+		project: Project,
+		ctx: AudioDownloadContext,
+		sel: QuaSelection
+	): Promise<AudioDownloadDone> {
+		const payload = await QuranicUniversalAudioService.getAudioUrl(sel.slug, sel.surahId);
 		const audioUrl = payload.audio_url ?? '';
 		if (!audioUrl) {
 			throw new Error('No audio is available for this recitation/chapter.');
 		}
 
-		await importChapterAudio(
+		const { bytes, fromCache } = await importChapterAudio(
+			project,
+			ctx.report,
 			audioUrl,
-			reciterName,
-			surahName,
 			{
 				quranicUniversalAudio: {
-					recitation: selectedSlug,
-					surah: selectedSurahId
+					recitation: sel.slug,
+					surah: sel.surahId
 				}
 			},
 			// Fichier chapitre complet : clé sans plage de versets.
-			quaCacheRelKey({ slug: selectedSlug, surah: selectedSurahId })
+			quaCacheRelKey({ slug: sel.slug, surah: sel.surahId })
 		);
+
+		return downloadDone(sel.surahName, bytes, fromCache);
 	}
 
-	/** Point d'entrée du bouton de téléchargement (route selon le mode courant). */
-	async function onDownload(): Promise<void> {
-		if (!selectedSlug || selectedSurahId === -1 || isDownloading) return;
-		isDownloading = true;
-		try {
-			if (mode === 'audio_only') {
-				await downloadAudioOnly();
-			} else {
-				await downloadAndApply();
-			}
-		} catch (error) {
-			console.error('Quranic Universal Audio error:', error);
-			toast.error(get(LL).editor.errorDownloading({ error: String(error) }), { duration: 5000 });
-		} finally {
-			isDownloading = false;
-			downloadProgress = null;
-			busyLabel = '';
-		}
+	/**
+	 * Point d'entrée du bouton. Fige la sélection et le projet ciblé, puis délègue au
+	 * store de téléchargement (détaché du composant) : la bascule d'onglet/fenêtre dans
+	 * QC n'interrompt plus le téléchargement, et une notification annonce la fin.
+	 */
+	function onDownload(): void {
+		const project = globalState.currentProject;
+		if (!project || !selectedSlug || selectedSurahId === -1 || isDownloading) return;
+
+		clampAyahRange();
+		const { reciterName, surahName } = currentNames();
+		const currentMode = mode;
+		const sel: QuaSelection = {
+			slug: selectedSlug,
+			surahId: selectedSurahId,
+			surahName,
+			from: ayahFrom,
+			to: ayahTo,
+			max: maxAyah,
+			fillBySilence,
+			extendBeforeSilence,
+			extendBeforeSilenceMs
+		};
+
+		void runAudioDownload({
+			projectId: project.detail.id,
+			section: 'qua',
+			label: get(LL).editor.downloadingSurah({ surah: surahName, reciter: reciterName }),
+			errorTitle: get(LL).editor.downloadFailed(),
+			run: (ctx) =>
+				currentMode === 'audio_only'
+					? downloadAudioOnly(project, ctx, sel)
+					: downloadAndApply(project, ctx, sel)
+		});
 	}
 </script>
 
@@ -552,10 +592,10 @@
 
 		<DownloadButton
 			idleLabel={get(LL).editor.downloadAudio()}
-			busyLabel={busyLabel || get(LL).editor.downloadingLabel()}
+			busyLabel={download.label || get(LL).editor.downloadingLabel()}
 			busy={isDownloading}
 			disabled={!selectedSlug || selectedSurahId === -1 || isDownloading}
-			progress={downloadProgress}
+			progress={download.progress}
 			onclick={onDownload}
 		/>
 	</div>

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import toast from 'svelte-5-french-toast';
-	import { invoke } from '@tauri-apps/api/core';
 	import { join } from '@tauri-apps/api/path';
 	import { openUrl } from '@tauri-apps/plugin-opener';
 	import { onMount } from 'svelte';
@@ -11,8 +10,14 @@
 	import { Quran, type Surah } from '$lib/classes/Quran';
 	import Section from '$lib/components/projectEditor/Section.svelte';
 	import SearchableSelect from '$lib/components/misc/SearchableSelect.svelte';
+	import DownloadButton from './DownloadButton.svelte';
 	import { globalState } from '$lib/runes/main.svelte';
 	import { applyPreloadSegmentsToProject } from '$lib/services/AutoSegmentation';
+	import {
+		bytesToMb,
+		downloadFileWithProgress,
+		type DownloadProgress
+	} from '$lib/services/DownloadWithProgress';
 	import { ProjectService } from '$lib/services/ProjectService';
 	import {
 		QuranicUniversalAudioService,
@@ -34,6 +39,9 @@
 	let ayahTo = $state(1);
 	let isLoadingRecitations = $state(true);
 	let isDownloading = $state(false);
+	// Progression + libellé de phase pilotant le bouton (aucun chiffre dans les toasts).
+	let downloadProgress = $state<DownloadProgress | null>(null);
+	let busyLabel = $state('');
 
 	// Options de segmentation (reprend les défauts de l'assistant auto-segmentation).
 	// Les timestamps mot à mot sont toujours fournis par le Preload → case forcée/désactivée.
@@ -159,9 +167,13 @@
 		surahName: string,
 		assetMeta: Record<string, unknown>
 	): Promise<void> {
-		const toastId = toast.loading(
-			get(LL).editor.downloadingSurah({ surah: surahName, reciter: reciterName })
-		);
+		const downloadingLabel = get(LL).editor.downloadingSurah({
+			surah: surahName,
+			reciter: reciterName
+		});
+		busyLabel = downloadingLabel;
+		downloadProgress = null;
+		const toastId = toast.loading(downloadingLabel);
 		try {
 			const downloadPath = await ProjectService.getAssetFolderForProject(
 				globalState.currentProject!.detail.id
@@ -171,7 +183,10 @@
 			if (!sanitizedBaseName) sanitizedBaseName = `surah-${selectedSurahId}`;
 			const fullPath = await join(downloadPath, `${sanitizedBaseName}.mp3`);
 
-			await invoke('download_file', { url: audioUrl, path: fullPath });
+			const downloadedBytes = await downloadFileWithProgress(audioUrl, fullPath, (progress) => {
+				downloadProgress = progress;
+			});
+			downloadProgress = null;
 
 			const asset = globalState.currentProject!.content.addAsset(
 				fullPath,
@@ -185,7 +200,9 @@
 			await asset.ensureDurationLoaded();
 			await asset.addToTimeline(false, true);
 
-			toast.success(get(LL).editor.downloadSuccessful(), { id: toastId });
+			toast.success(`${get(LL).editor.downloadSuccessful()} (${bytesToMb(downloadedBytes)} MB)`, {
+				id: toastId
+			});
 		} catch (error) {
 			toast.dismiss(toastId);
 			throw error;
@@ -211,7 +228,16 @@
 			throw new Error('No pre-aligned segments are available for this selection.');
 		}
 
-		await importChapterAudio(audioUrl, reciterName, surahName, {
+		// Le proxy renvoie une URL de clip (`?start_ms=&end_ms=`) et refuse (400
+		// « clip window too large ») les fenêtres trop longues — ce qui casse les
+		// récitations Mujawwad d'une sourate entière (plusieurs heures). Quand la
+		// sélection couvre toute la sourate depuis le début, le clip = le fichier
+		// complet : on télécharge directement le mp3 non tronqué, qui n'a pas de
+		// limite de fenêtre. Les timestamps restent absolus depuis 0 → inchangés.
+		const isFullSurah = ayahFrom === 1 && ayahTo === maxAyah;
+		const downloadUrl = isFullSurah ? audioUrl.split('?')[0] : audioUrl;
+
+		await importChapterAudio(downloadUrl, reciterName, surahName, {
 			quranicUniversalAudio: {
 				recitation: selectedSlug,
 				surah: selectedSurahId,
@@ -220,7 +246,11 @@
 			}
 		});
 
-		// Segments pré-alignés (sans ré-enrichissement MFA).
+		// Segments pré-alignés (sans ré-enrichissement MFA). Sur une longue sourate
+		// l'application des clips prend plusieurs secondes : le bouton passe en état
+		// « Applying… » indéterminé (l'UI reste réactive grâce au yield coopératif).
+		busyLabel = 'Applying segments to the timeline…';
+		downloadProgress = null;
 		await applyPreloadSegmentsToProject(payload, {
 			fillBySilence,
 			extendBeforeSilence,
@@ -261,6 +291,8 @@
 			toast.error(get(LL).editor.errorDownloading({ error: String(error) }), { duration: 5000 });
 		} finally {
 			isDownloading = false;
+			downloadProgress = null;
+			busyLabel = '';
 		}
 	}
 </script>
@@ -447,19 +479,13 @@
 			</div>
 		{/if}
 
-		<button
-			class="btn-accent relative flex w-full items-center justify-center gap-2 overflow-hidden rounded-lg px-4 py-3 text-sm font-medium shadow-lg transition-all duration-200 hover:scale-[1.02] hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100"
-			type="button"
-			onclick={onDownload}
+		<DownloadButton
+			idleLabel={get(LL).editor.downloadAudio()}
+			busyLabel={busyLabel || get(LL).editor.downloadingLabel()}
+			busy={isDownloading}
 			disabled={!selectedSlug || selectedSurahId === -1 || isDownloading}
-		>
-			{#if isDownloading}
-				<span class="material-icons animate-spin text-lg">sync</span>
-				<span>{get(LL).editor.downloadingLabel()}</span>
-			{:else}
-				<span class="material-icons text-lg">download</span>
-				<span>{get(LL).editor.downloadAudio()}</span>
-			{/if}
-		</button>
+			progress={downloadProgress}
+			onclick={onDownload}
+		/>
 	</div>
 </Section>

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
@@ -228,16 +228,14 @@
 			throw new Error('No pre-aligned segments are available for this selection.');
 		}
 
-		// Le proxy renvoie une URL de clip (`?start_ms=&end_ms=`) et refuse (400
-		// « clip window too large ») les fenêtres trop longues — ce qui casse les
-		// récitations Mujawwad d'une sourate entière (plusieurs heures). Quand la
-		// sélection couvre toute la sourate depuis le début, le clip = le fichier
-		// complet : on télécharge directement le mp3 non tronqué, qui n'a pas de
-		// limite de fenêtre. Les timestamps restent absolus depuis 0 → inchangés.
-		const isFullSurah = ayahFrom === 1 && ayahTo === maxAyah;
-		const downloadUrl = isFullSurah ? audioUrl.split('?')[0] : audioUrl;
-
-		await importChapterAudio(downloadUrl, reciterName, surahName, {
+		// On télécharge l'URL de clip (`?start_ms=&end_ms=`) telle quelle : les
+		// timestamps des segments Preload sont RELATIFS au début de la fenêtre de
+		// clip (0 = start_ms), pas absolus depuis 0 du fichier chapitre. Télécharger
+		// le mp3 complet non tronqué décalait donc tout d'un offset constant (le
+		// silence/isti'adha/basmala en tête de fichier avant la plage alignée). Le
+		// cap serveur qui renvoyait 400 sur les longues fenêtres a été retiré côté
+		// aligner, donc la fenêtre de clip complète stream sans limite de durée.
+		await importChapterAudio(audioUrl, reciterName, surahName, {
 			quranicUniversalAudio: {
 				recitation: selectedSlug,
 				surah: selectedSurahId,

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import toast from 'svelte-5-french-toast';
-	import { join } from '@tauri-apps/api/path';
+	import { exists, stat } from '@tauri-apps/plugin-fs';
 	import { openUrl } from '@tauri-apps/plugin-opener';
 	import { onMount } from 'svelte';
 	import LL from '$lib/i18n/i18n-svelte';
@@ -18,7 +18,7 @@
 		downloadFileWithProgress,
 		type DownloadProgress
 	} from '$lib/services/DownloadWithProgress';
-	import { ProjectService } from '$lib/services/ProjectService';
+	import { quaCacheRelKey, resolveQuaCachePath } from '$lib/services/QuaAudioCache';
 	import {
 		QuranicUniversalAudioService,
 		type QuaRecitation
@@ -158,14 +158,19 @@
 	}
 
 	/**
-	 * Télécharge le mp3 du chapitre complet, l'ajoute comme asset puis le pose sur
-	 * la piste audio. Gère les toasts de progression ; relance l'erreur au caller.
+	 * Télécharge le mp3 du chapitre (ou le réutilise depuis le cache partagé QUA),
+	 * l'ajoute comme asset puis le pose sur la piste audio. `cacheKey` identifie de
+	 * façon déterministe l'audio (récitateur + sourate + plage) : un fichier déjà
+	 * présent est réutilisé tel quel, sans re-téléchargement ni copie par projet —
+	 * l'`Asset.filePath` pointe directement sur le fichier du cache. Gère les toasts
+	 * de progression ; relance l'erreur au caller.
 	 */
 	async function importChapterAudio(
 		audioUrl: string,
 		reciterName: string,
 		surahName: string,
-		assetMeta: Record<string, unknown>
+		assetMeta: Record<string, unknown>,
+		cacheKey: string
 	): Promise<void> {
 		const downloadingLabel = get(LL).editor.downloadingSurah({
 			surah: surahName,
@@ -175,21 +180,23 @@
 		downloadProgress = null;
 		const toastId = toast.loading(downloadingLabel);
 		try {
-			const downloadPath = await ProjectService.getAssetFolderForProject(
-				globalState.currentProject!.detail.id
-			);
-			const rawBaseName = `${reciterName} - ${surahName}`;
-			let sanitizedBaseName = rawBaseName.replace(/[<>:"/\\|?*]/g, '').trim();
-			if (!sanitizedBaseName) sanitizedBaseName = `surah-${selectedSurahId}`;
-			const fullPath = await join(downloadPath, `${sanitizedBaseName}.mp3`);
+			const cachePath = await resolveQuaCachePath(cacheKey);
 
-			const downloadedBytes = await downloadFileWithProgress(audioUrl, fullPath, (progress) => {
-				downloadProgress = progress;
-			});
+			// Cache hit → aucun HTTP : on lit juste la taille pour le toast.
+			let downloadedBytes: number;
+			let fromCache = false;
+			if (await exists(cachePath)) {
+				fromCache = true;
+				downloadedBytes = (await stat(cachePath)).size;
+			} else {
+				downloadedBytes = await downloadFileWithProgress(audioUrl, cachePath, (progress) => {
+					downloadProgress = progress;
+				});
+			}
 			downloadProgress = null;
 
 			const asset = globalState.currentProject!.content.addAsset(
-				fullPath,
+				cachePath,
 				audioUrl,
 				SourceType.QuranicUniversalAudio,
 				assetMeta
@@ -200,9 +207,11 @@
 			await asset.ensureDurationLoaded();
 			await asset.addToTimeline(false, true);
 
-			toast.success(`${get(LL).editor.downloadSuccessful()} (${bytesToMb(downloadedBytes)} MB)`, {
-				id: toastId
-			});
+			const cachedSuffix = fromCache ? ', cached' : '';
+			toast.success(
+				`${get(LL).editor.downloadSuccessful()} (${bytesToMb(downloadedBytes)} MB${cachedSuffix})`,
+				{ id: toastId }
+			);
 		} catch (error) {
 			toast.dismiss(toastId);
 			throw error;
@@ -235,14 +244,26 @@
 		// silence/isti'adha/basmala en tête de fichier avant la plage alignée). Le
 		// cap serveur qui renvoyait 400 sur les longues fenêtres a été retiré côté
 		// aligner, donc la fenêtre de clip complète stream sans limite de durée.
-		await importChapterAudio(audioUrl, reciterName, surahName, {
-			quranicUniversalAudio: {
-				recitation: selectedSlug,
+		await importChapterAudio(
+			audioUrl,
+			reciterName,
+			surahName,
+			{
+				quranicUniversalAudio: {
+					recitation: selectedSlug,
+					surah: selectedSurahId,
+					verseFrom: ayahFrom,
+					verseTo: ayahTo
+				}
+			},
+			// Clip des versets : la clé inclut la plage (octets dépendants de [from,to]).
+			quaCacheRelKey({
+				slug: selectedSlug,
 				surah: selectedSurahId,
 				verseFrom: ayahFrom,
 				verseTo: ayahTo
-			}
-		});
+			})
+		);
 
 		// Segments pré-alignés (sans ré-enrichissement MFA). Sur une longue sourate
 		// l'application des clips prend plusieurs secondes : le bouton passe en état
@@ -266,12 +287,19 @@
 			throw new Error('No audio is available for this recitation/chapter.');
 		}
 
-		await importChapterAudio(audioUrl, reciterName, surahName, {
-			quranicUniversalAudio: {
-				recitation: selectedSlug,
-				surah: selectedSurahId
-			}
-		});
+		await importChapterAudio(
+			audioUrl,
+			reciterName,
+			surahName,
+			{
+				quranicUniversalAudio: {
+					recitation: selectedSlug,
+					surah: selectedSurahId
+				}
+			},
+			// Fichier chapitre complet : clé sans plage de versets.
+			quaCacheRelKey({ slug: selectedSlug, surah: selectedSurahId })
+		);
 	}
 
 	/** Point d'entrée du bouton de téléchargement (route selon le mode courant). */

--- a/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
+++ b/src/lib/components/projectEditor/tabs/videoEditor/assetsManager/DownloadFromQuranicUniversalAudioSection.svelte
@@ -170,7 +170,8 @@
 		reciterName: string,
 		surahName: string,
 		assetMeta: Record<string, unknown>,
-		cacheKey: string
+		cacheKey: string,
+		downloadUrl: string = audioUrl
 	): Promise<void> {
 		const downloadingLabel = get(LL).editor.downloadingSurah({
 			surah: surahName,
@@ -182,14 +183,16 @@
 		try {
 			const cachePath = await resolveQuaCachePath(cacheKey);
 
-			// Cache hit → aucun HTTP : on lit juste la taille pour le toast.
+			// Cache hit → aucun HTTP : on lit juste la taille pour le toast. Sinon on
+			// télécharge la fenêtre audio choisie (`downloadUrl`), en gardant l'URL
+			// serveur d'origine (`audioUrl`) comme provenance de l'asset.
 			let downloadedBytes: number;
 			let fromCache = false;
 			if (await exists(cachePath)) {
 				fromCache = true;
 				downloadedBytes = (await stat(cachePath)).size;
 			} else {
-				downloadedBytes = await downloadFileWithProgress(audioUrl, cachePath, (progress) => {
+				downloadedBytes = await downloadFileWithProgress(downloadUrl, cachePath, (progress) => {
 					downloadProgress = progress;
 				});
 			}
@@ -237,13 +240,14 @@
 			throw new Error('No pre-aligned segments are available for this selection.');
 		}
 
-		// On télécharge l'URL de clip (`?start_ms=&end_ms=`) telle quelle : les
-		// timestamps des segments Preload sont RELATIFS au début de la fenêtre de
-		// clip (0 = start_ms), pas absolus depuis 0 du fichier chapitre. Télécharger
-		// le mp3 complet non tronqué décalait donc tout d'un offset constant (le
-		// silence/isti'adha/basmala en tête de fichier avant la plage alignée). Le
-		// cap serveur qui renvoyait 400 sur les longues fenêtres a été retiré côté
-		// aligner, donc la fenêtre de clip complète stream sans limite de durée.
+		// Les timestamps Preload sont RELATIFS au début de la fenêtre de clip
+		// (0 = start_ms). Plutôt que jeter l'audio hors de la plage, on élargit la
+		// fenêtre téléchargée aux frontières « spéciales » de la sourate — isti'adha
+		// /basmala de tête quand le verset 1 est inclus, clôture de fin quand le
+		// dernier verset l'est — puis on réaligne les sous-titres via un décalage.
+		const window = computeAudioWindow(audioUrl);
+		const downloadUrl = window.downloadUrl;
+
 		await importChapterAudio(
 			audioUrl,
 			reciterName,
@@ -256,13 +260,8 @@
 					verseTo: ayahTo
 				}
 			},
-			// Clip des versets : la clé inclut la plage (octets dépendants de [from,to]).
-			quaCacheRelKey({
-				slug: selectedSlug,
-				surah: selectedSurahId,
-				verseFrom: ayahFrom,
-				verseTo: ayahTo
-			})
+			window.cacheKey,
+			downloadUrl
 		);
 
 		// Segments pré-alignés (sans ré-enrichissement MFA). Sur une longue sourate
@@ -273,8 +272,54 @@
 		await applyPreloadSegmentsToProject(payload, {
 			fillBySilence,
 			extendBeforeSilence,
-			extendBeforeSilenceMs
+			extendBeforeSilenceMs,
+			timeOffsetMs: window.timeOffsetMs
 		});
+	}
+
+	/** Borne haute « fin de fichier » : ffmpeg tronque à l'EOF réel (24 h en ms). */
+	const AUDIO_END_SENTINEL_MS = 24 * 60 * 60 * 1000;
+
+	/**
+	 * Élargit la fenêtre de clip Preload aux frontières de sourate demandées, sans
+	 * jamais tronquer l'audio « spécial » : garde l'intro (isti'adha/basmala) quand
+	 * le verset 1 est dans la plage, et la clôture quand le dernier verset l'est.
+	 *
+	 * @param audioUrl URL de clip renvoyée par le serveur (`?start_ms=&end_ms=`).
+	 * @returns URL à télécharger, clé de cache et décalage temporel des sous-titres.
+	 */
+	function computeAudioWindow(audioUrl: string): {
+		downloadUrl: string;
+		cacheKey: string;
+		timeOffsetMs: number;
+	} {
+		const base = audioUrl.split('?')[0];
+		const params = new URL(audioUrl).searchParams;
+		const origStart = Number.parseInt(params.get('start_ms') ?? '0', 10) || 0;
+		const origEnd = Number.parseInt(params.get('end_ms') ?? '0', 10) || 0;
+
+		const keepIntro = ayahFrom === 1; // le verset 1 amène l'isti'adha/basmala de tête.
+		const keepOutro = ayahTo === maxAyah; // le dernier verset amène la clôture de fin.
+		const audioStart = keepIntro ? 0 : origStart;
+		const isFullSurah = keepIntro && keepOutro;
+
+		// Sourate entière → fichier chapitre complet non tronqué (mêmes octets que le
+		// mode audio seul → clé partagée `<slug>/<surah>.mp3`).
+		const downloadUrl = isFullSurah
+			? base
+			: `${base}?start_ms=${audioStart}&end_ms=${keepOutro ? AUDIO_END_SENTINEL_MS : origEnd}`;
+
+		const cacheKey = isFullSurah
+			? quaCacheRelKey({ slug: selectedSlug, surah: selectedSurahId })
+			: quaCacheRelKey({
+					slug: selectedSlug,
+					surah: selectedSurahId,
+					verseFrom: ayahFrom,
+					verseTo: ayahTo
+				});
+
+		// Position d'un segment dans la fenêtre = temps relatif + (origStart − audioStart).
+		return { downloadUrl, cacheKey, timeOffsetMs: origStart - audioStart };
 	}
 
 	/** Audio seul : télécharge le chapitre complet, sans aucun segment. */

--- a/src/lib/components/projectEditor/timeline/Timeline.svelte
+++ b/src/lib/components/projectEditor/timeline/Timeline.svelte
@@ -27,10 +27,12 @@
 
 	let totalDuration = $derived(() => {
 		// Récupère la fin du clip le plus loin dans la timeline
+		const project = globalState.currentProject;
 		const longestClipEnd =
-			globalState.currentProject?.content.timeline.getLongestTrackDuration() ?? new Duration(0);
+			project?.content.timeline.getLongestTrackDuration() ?? new Duration(0);
 
-		globalState.currentProject!.detail.duration = longestClipEnd;
+		// Pas de projet ouvert (fermeture/rechargement HMR) : ne pas déréférencer null.
+		if (project) project.detail.duration = longestClipEnd;
 
 		if (!longestClipEnd.isNull())
 			return new Duration(

--- a/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
+++ b/src/lib/components/projectEditor/timeline/track/SubtitleClip.svelte
@@ -23,6 +23,7 @@
 		AUTO_REALIGN_DRAG_THRESHOLD_MS
 	} from '$lib/services/AutoSegmentation';
 	import LL from '$lib/i18n/i18n-svelte';
+	import { stripWbwDisplayMarkers } from '$lib/services/WbwHelper';
 	import { ProjectHistoryManager } from '$lib/services/undoRedo/ProjectHistoryManager';
 
 	let {
@@ -145,7 +146,8 @@
 	 * @returns {string} Texte lisible du mot.
 	 */
 	function getWordBoundaryLabel(word: { location: string; word?: string }): string {
-		const directLabel = String(word.word ?? '').trim();
+		// Retire le petit zéro rond « lettre muette » à l'affichage uniquement.
+		const directLabel = stripWbwDisplayMarkers(String(word.word ?? '').trim());
 		if (directLabel) return directLabel;
 		if (!(clip instanceof SubtitleClip)) return String(word.location ?? '').trim();
 

--- a/src/lib/components/projectEditor/timeline/track/WbwSubtitleClipEditor.svelte
+++ b/src/lib/components/projectEditor/timeline/track/WbwSubtitleClipEditor.svelte
@@ -3,6 +3,7 @@
 	import { globalState } from '$lib/runes/main.svelte';
 	import {
 		getSubtitleClipDurationSeconds,
+		stripWbwDisplayMarkers,
 		updateManualWordByWordBoundary
 	} from '$lib/services/WbwHelper';
 	import { onDestroy } from 'svelte';
@@ -41,7 +42,8 @@
 
 			return {
 				location: word.location,
-				word: word.word,
+				// Retire le petit zéro rond « lettre muette » à l'affichage uniquement.
+				word: stripWbwDisplayMarkers(word.word),
 				start,
 				end,
 				leftPercent,

--- a/src/lib/services/AudioDownloadStore.svelte.ts
+++ b/src/lib/services/AudioDownloadStore.svelte.ts
@@ -92,13 +92,21 @@ export async function runAudioDownload(params: {
 
 	try {
 		const done = await params.run(ctx);
-		await notifyLongTaskCompletion({ title: done.title, body: done.body, level: 'success' });
+		// Skip la notif système si la fenêtre est focus : la progression + fin sont déjà
+		// visibles dans le bouton. Utile surtout quand l'utilisateur est parti ailleurs.
+		await notifyLongTaskCompletion({
+			title: done.title,
+			body: done.body,
+			level: 'success',
+			skipWhenFocused: true
+		});
 	} catch (error) {
 		console.error('Audio download error:', error);
 		await notifyLongTaskCompletion({
 			title: params.errorTitle,
 			body: String(error),
-			level: 'error'
+			level: 'error',
+			skipWhenFocused: true
 		});
 	} finally {
 		entries[key] = { ...IDLE };

--- a/src/lib/services/AudioDownloadStore.svelte.ts
+++ b/src/lib/services/AudioDownloadStore.svelte.ts
@@ -1,0 +1,106 @@
+import type { DownloadProgress } from '$lib/services/DownloadWithProgress';
+import { notifyLongTaskCompletion } from '$lib/services/UserAttentionService';
+
+/**
+ * Store de téléchargement audio détaché du cycle de vie des composants.
+ *
+ * Les panneaux de téléchargement (Quranic Universal Audio, sources Quran) vivent
+ * sous l'onglet Video Editor, qui est démonté dès qu'on change d'onglet dans QC
+ * (`{#if currentTab === VideoEditor}`). Un `$state` local au composant serait donc
+ * détruit à chaque bascule d'onglet/fenêtre : progression perdue, bouton réarmé
+ * (double téléchargement possible), aucun retour de fin.
+ *
+ * En hébergeant l'état ici (module `$state`, hors composant), un téléchargement en
+ * cours survit à ces bascules : au remontage, le bouton retrouve son état occupé
+ * et sa progression. À la fin, on émet une notification système (même motif que
+ * l'export / la segmentation) car l'utilisateur peut être ailleurs.
+ */
+
+/** Section émettrice — un projet peut télécharger depuis deux panneaux à la fois. */
+export type AudioDownloadSection = 'qua' | 'quranSource';
+
+/** État réactif d'un téléchargement pour un couple (projet, section). */
+export type AudioDownloadEntry = {
+	busy: boolean;
+	label: string;
+	progress: DownloadProgress | null;
+};
+
+const IDLE: AudioDownloadEntry = { busy: false, label: '', progress: null };
+
+// Clé `${projectId}:${section}`. `$state` de module → survit au démontage des
+// composants (bascule d'onglet/fenêtre dans QC).
+const entries = $state<Record<string, AudioDownloadEntry>>({});
+
+function keyOf(projectId: number, section: AudioDownloadSection): string {
+	return `${projectId}:${section}`;
+}
+
+/** État courant du téléchargement (objet IDLE stable si aucun en cours). */
+export function getAudioDownload(
+	projectId: number,
+	section: AudioDownloadSection
+): AudioDownloadEntry {
+	return entries[keyOf(projectId, section)] ?? IDLE;
+}
+
+/** Un téléchargement est-il déjà en cours pour ce couple (projet, section) ? */
+export function isAudioDownloadBusy(projectId: number, section: AudioDownloadSection): boolean {
+	return entries[keyOf(projectId, section)]?.busy ?? false;
+}
+
+/** Notification de fin fournie par le travail (titre + corps, ex. taille en Mo). */
+export type AudioDownloadDone = { title: string; body: string };
+
+/** Contexte passé au travail pour publier progression et libellé en direct. */
+export type AudioDownloadContext = {
+	report: (progress: DownloadProgress | null) => void;
+	setLabel: (label: string) => void;
+};
+
+/**
+ * Exécute un téléchargement audio détaché de tout composant. L'état vit dans le
+ * store (survit aux bascules d'onglet/fenêtre) ; un doublon est ignoré tant qu'un
+ * téléchargement est actif pour le même couple (projet, section). À la fin, émet
+ * une notification système (succès avec la taille téléchargée, ou échec).
+ *
+ * Ne relance jamais : le travail est détaché (l'appelant peut être démonté), donc
+ * toute erreur est journalisée et notifiée ici, pas propagée.
+ */
+export async function runAudioDownload(params: {
+	projectId: number;
+	section: AudioDownloadSection;
+	label: string;
+	errorTitle: string;
+	run: (ctx: AudioDownloadContext) => Promise<AudioDownloadDone>;
+}): Promise<void> {
+	const key = keyOf(params.projectId, params.section);
+	if (entries[key]?.busy) return; // garde anti-doublon.
+
+	entries[key] = { busy: true, label: params.label, progress: null };
+
+	const ctx: AudioDownloadContext = {
+		report: (progress) => {
+			const entry = entries[key];
+			if (entry) entries[key] = { ...entry, progress };
+		},
+		setLabel: (label) => {
+			const entry = entries[key];
+			if (entry) entries[key] = { ...entry, label, progress: null };
+		}
+	};
+
+	try {
+		const done = await params.run(ctx);
+		await notifyLongTaskCompletion({ title: done.title, body: done.body, level: 'success' });
+	} catch (error) {
+		console.error('Audio download error:', error);
+		await notifyLongTaskCompletion({
+			title: params.errorTitle,
+			body: String(error),
+			level: 'error'
+		});
+	} finally {
+		entries[key] = { ...IDLE };
+	}
+}

--- a/src/lib/services/BatchService.ts
+++ b/src/lib/services/BatchService.ts
@@ -10,6 +10,7 @@ import {
 import type { ValidatedBatchRow } from '$lib/components/batch/batchCsv';
 import { globalState } from '$lib/runes/main.svelte';
 import { ProjectService } from '$lib/services/ProjectService';
+import { pruneOrphanedQuaCache } from '$lib/services/QuaAudioCache';
 import { DEFAULT_PROJECT_TYPE } from '$lib/types/projectType';
 import { join } from '@tauri-apps/api/path';
 import { exists, readDir, readTextFile, remove, writeTextFile } from '@tauri-apps/plugin-fs';
@@ -242,7 +243,14 @@ export class BatchService {
 		const filePath = await join(await this.getBatchesFolderPath(), `${batchId}.json`);
 		if (!(await exists(filePath))) return;
 		const batch = await this.load(batchId);
-		await Promise.all(batch.projects.map((project) => ProjectService.delete(project.projectId)));
+		// Suppression concurrente : on désactive la purge par projet et on purge le
+		// cache QUA une seule fois après (évite course + rechargements O(n²)).
+		await Promise.all(
+			batch.projects.map((project) =>
+				ProjectService.delete(project.projectId, { sweepQuaCache: false })
+			)
+		);
+		await pruneOrphanedQuaCache();
 		await remove(filePath);
 		globalState.userBatchDetails = globalState.userBatchDetails.filter(
 			(detail) => detail.id !== batchId
@@ -287,11 +295,13 @@ export class BatchService {
 	 */
 	static async deleteProjects(batch: Batch, projectIds: number[]): Promise<void> {
 		const selectedIds = new Set(projectIds);
+		// Purge du cache QUA une seule fois après la suppression concurrente.
 		await Promise.all(
 			batch.projects
 				.filter((project) => selectedIds.has(project.projectId))
-				.map((project) => ProjectService.delete(project.projectId))
+				.map((project) => ProjectService.delete(project.projectId, { sweepQuaCache: false }))
 		);
+		await pruneOrphanedQuaCache();
 		batch.projects = batch.projects.filter((project) => !selectedIds.has(project.projectId));
 		batch.updatedAt = new Date();
 		await this.save(batch);

--- a/src/lib/services/DownloadWithProgress.ts
+++ b/src/lib/services/DownloadWithProgress.ts
@@ -1,0 +1,53 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+/** Progression d'un téléchargement. `total` est null si l'hôte n'annonce pas de taille. */
+export type DownloadProgress = {
+	downloaded: number;
+	total: number | null;
+};
+
+type DownloadProgressEvent = {
+	downloadId: string;
+	downloaded: number;
+	total: number | null;
+};
+
+let counter = 0;
+
+/** Formate un nombre d'octets en Mo à une décimale (ex. `12.3`). */
+export function bytesToMb(bytes: number): string {
+	return (bytes / (1024 * 1024)).toFixed(1);
+}
+
+/**
+ * Télécharge un fichier via la commande Rust `download_file` en relayant sa
+ * progression. Corrèle les events `download-progress` par `downloadId` pour que
+ * plusieurs téléchargements simultanés ne se mélangent pas.
+ *
+ * @param url URL source.
+ * @param path Chemin de destination sur disque.
+ * @param onProgress Callback appelé (throttlé côté Rust ~5x/s) à chaque avancée.
+ * @returns Nombre d'octets téléchargés.
+ */
+export async function downloadFileWithProgress(
+	url: string,
+	path: string,
+	onProgress?: (progress: DownloadProgress) => void
+): Promise<number> {
+	const downloadId = `dl-${Date.now()}-${counter++}`;
+	let unlisten: (() => void) | undefined;
+
+	if (onProgress) {
+		unlisten = await listen<DownloadProgressEvent>('download-progress', (event) => {
+			if (event.payload.downloadId !== downloadId) return;
+			onProgress({ downloaded: event.payload.downloaded, total: event.payload.total ?? null });
+		});
+	}
+
+	try {
+		return (await invoke('download_file', { url, path, downloadId })) as number;
+	} finally {
+		unlisten?.();
+	}
+}

--- a/src/lib/services/ProjectService.ts
+++ b/src/lib/services/ProjectService.ts
@@ -2,6 +2,7 @@ import { Project, ProjectContent, ProjectDetail, Utilities, VideoStyle } from '$
 import { readDir, remove, writeTextFile, readTextFile, exists, mkdir } from '@tauri-apps/plugin-fs';
 import { appDataDir, join } from '@tauri-apps/api/path';
 import { globalState } from '$lib/runes/main.svelte';
+import { projectJsonReferencesQuaCache, pruneOrphanedQuaCache } from '$lib/services/QuaAudioCache';
 import type { ImportedProjectPayload } from '$lib/types/project';
 import { DEFAULT_PROJECT_TYPE, type ProjectType } from '$lib/types/projectType';
 import LL from '$lib/i18n/i18n-svelte';
@@ -222,13 +223,29 @@ export class ProjectService {
 	/**
 	 * Supprime un projet de l'ordinateur.
 	 * @param projectId L'id du projet à supprimer
+	 * @param options `sweepQuaCache` (défaut true) : après suppression, purge les
+	 *   fichiers du cache audio QUA que plus aucun projet ne référence. Les chemins
+	 *   de suppression en lot (BatchService) passent false et purgent une seule fois
+	 *   à la fin pour éviter une course + un rechargement O(n²) des JSON de projet.
 	 */
-	static async delete(projectId: number): Promise<void> {
+	static async delete(
+		projectId: number,
+		options: { sweepQuaCache?: boolean } = {}
+	): Promise<void> {
 		const projectsPath = await join(await appDataDir(), this.projectsFolder);
+
+		// Détecte AVANT suppression si ce projet référençait le cache QUA : la purge
+		// (coûteuse, scanne tous les projets) ne se déclenche que dans ce cas.
+		let referencedQuaCache = false;
 
 		try {
 			// Construis le chemin d'accès vers le projet
 			const filePath = await join(projectsPath, `${projectId}.json`);
+			try {
+				referencedQuaCache = projectJsonReferencesQuaCache(await readTextFile(filePath));
+			} catch {
+				// JSON illisible/déjà absent : rien à purger pour ce projet.
+			}
 			await remove(filePath);
 
 			// Supprime le dossier des assets associés au projet
@@ -236,6 +253,13 @@ export class ProjectService {
 			await remove(assetsPath, { recursive: true });
 		} catch (_e) {
 			// Le projet n'avait pas d'asset
+		}
+
+		// Purge « eager » du cache partagé : l'audio QUA vit hors du dossier par
+		// projet, donc le remove ci-dessus ne le touche pas. On supprime ici tout
+		// fichier de cache devenu orphelin (plus référencé par aucun projet).
+		if ((options.sweepQuaCache ?? true) && referencedQuaCache) {
+			await pruneOrphanedQuaCache();
 		}
 
 		// Le supprime de la liste des projets

--- a/src/lib/services/QuaAudioCache.ts
+++ b/src/lib/services/QuaAudioCache.ts
@@ -1,0 +1,174 @@
+import { appDataDir, join } from '@tauri-apps/api/path';
+import { exists, mkdir, readDir, readTextFile, remove } from '@tauri-apps/plugin-fs';
+
+/**
+ * Cache partagé pour les audios « Quranic Universal Audio » (QUA).
+ *
+ * Un même récitateur+sourate téléchargé depuis QUA produit toujours les mêmes
+ * octets (fichier de bucket non tronqué pour une sourate entière, découpe ffmpeg
+ * déterministe pour une plage de versets). On le stocke donc une seule fois ici,
+ * hors des dossiers d'assets par projet, et chaque `Asset.filePath` pointe
+ * directement sur ce fichier partagé : zéro re-téléchargement et zéro copie
+ * dupliquée sur le disque entre projets.
+ *
+ * Nettoyage par comptage de références « eager » : à la suppression d'un projet,
+ * {@link pruneOrphanedQuaCache} supprime tout fichier de cache que plus aucun
+ * projet ne référence (voir ProjectService.delete / BatchService).
+ */
+
+export const QUA_CACHE_FOLDER = 'qua-audio-cache';
+const PROJECTS_FOLDER = 'projects/';
+
+/** Normalise un chemin pour comparaison : `/` uniforme, doublons réduits, minuscule (Windows). */
+function normalizeForCompare(filePath: string): string {
+	return filePath
+		.replace(/\\/g, '/')
+		.replace(/\/+/g, '/')
+		.toLowerCase();
+}
+
+/** Dossier du cache (`<appData>/qua-audio-cache`), créé si absent. */
+export async function getQuaCacheDir(): Promise<string> {
+	const dir = await join(await appDataDir(), QUA_CACHE_FOLDER);
+	if (!(await exists(dir))) {
+		await mkdir(dir, { recursive: true });
+	}
+	return dir;
+}
+
+/** Paramètres identifiant de façon stable un audio QUA téléchargeable. */
+export type QuaCacheKeyParams = {
+	/** Slug de livraison (identifiant immuable du récitateur, sûr pour un chemin). */
+	slug: string;
+	/** Numéro de sourate. */
+	surah: number;
+	/**
+	 * Plage de versets, présente uniquement en mode « audio + segments ». Le mot
+	 * à mot Preload télécharge le clip `[verseFrom, verseTo]` (timestamps relatifs
+	 * au début de la fenêtre), donc les octets dépendent de la plage — même une
+	 * sourate entière exclut l'isti'adha/basmala de tête et diffère du fichier
+	 * complet. En mode « audio seul » ces champs sont absents (fichier complet).
+	 */
+	verseFrom?: number;
+	verseTo?: number;
+};
+
+/**
+ * Construit la clé de cache relative (`<slug>/<surah>[-<from>-<to>].mp3`).
+ *
+ * Basée sur le slug (immuable) + sourate + plage de versets, jamais sur le nom
+ * d'affichage du récitateur (qui peut changer). Une plage présente → clip des
+ * versets ; absente → fichier chapitre complet (mode audio seul).
+ */
+export function quaCacheRelKey(params: QuaCacheKeyParams): string {
+	const { slug, surah, verseFrom, verseTo } = params;
+	const hasRange = verseFrom != null && verseTo != null;
+	const fileName = hasRange ? `${surah}-${verseFrom}-${verseTo}.mp3` : `${surah}.mp3`;
+	return `${slug}/${fileName}`;
+}
+
+/**
+ * Résout la clé relative en chemin absolu dans le cache, en créant le
+ * sous-dossier du slug au besoin. Chemin retourné normalisé en `/`.
+ */
+export async function resolveQuaCachePath(relKey: string): Promise<string> {
+	const cacheDir = await getQuaCacheDir();
+	const parts = relKey.split('/').filter(Boolean);
+	const fullPath = await join(cacheDir, ...parts);
+	// Crée le sous-dossier du slug (parent du fichier) si nécessaire.
+	if (parts.length > 1) {
+		const slugDir = await join(cacheDir, ...parts.slice(0, -1));
+		if (!(await exists(slugDir))) {
+			await mkdir(slugDir, { recursive: true });
+		}
+	}
+	return fullPath.replace(/\\/g, '/');
+}
+
+/** Indique si `filePath` se trouve dans le dossier de cache QUA. */
+export async function isQuaCachePath(filePath: string): Promise<boolean> {
+	const cacheDirNorm = normalizeForCompare(await getQuaCacheDir());
+	return normalizeForCompare(filePath).startsWith(cacheDirNorm + '/');
+}
+
+/** Test rapide (sans parse) : un JSON de projet référence-t-il le cache QUA ? */
+export function projectJsonReferencesQuaCache(jsonText: string): boolean {
+	return jsonText.includes(QUA_CACHE_FOLDER);
+}
+
+/**
+ * Rassemble l'ensemble des fichiers de cache encore référencés par au moins un
+ * projet sur le disque (chemins normalisés). Lit les JSON directement pour
+ * rester léger et éviter une dépendance circulaire avec ProjectService.
+ */
+async function collectReferencedCacheFiles(): Promise<Set<string>> {
+	const referenced = new Set<string>();
+	const projectsPath = await join(await appDataDir(), PROJECTS_FOLDER);
+	if (!(await exists(projectsPath))) return referenced;
+
+	const cacheDirNorm = normalizeForCompare(await getQuaCacheDir());
+	const entries = await readDir(projectsPath);
+	for (const entry of entries) {
+		if (!entry.isFile || !entry.name?.endsWith('.json')) continue;
+		try {
+			const filePath = await join(projectsPath, entry.name);
+			const text = await readTextFile(filePath);
+			// Court-circuit : ignore les projets qui ne touchent pas au cache.
+			if (!projectJsonReferencesQuaCache(text)) continue;
+			const data = JSON.parse(text);
+			const assets: Array<{ filePath?: string }> = data?.content?.assets ?? [];
+			for (const asset of assets) {
+				if (typeof asset?.filePath !== 'string') continue;
+				const norm = normalizeForCompare(asset.filePath);
+				if (norm.startsWith(cacheDirNorm + '/')) referenced.add(norm);
+			}
+		} catch (error) {
+			// Projet illisible/corrompu : on le saute (comme loadUserProjectsDetails).
+			console.warn(`QUA cache prune: could not read ${entry.name}:`, error);
+		}
+	}
+	return referenced;
+}
+
+/**
+ * Supprime les fichiers de cache QUA que plus aucun projet ne référence, puis
+ * les sous-dossiers de slug devenus vides. Idempotent et auto-réparateur : il
+ * ramasse aussi les orphelins laissés par un crash en cours de suppression.
+ */
+export async function pruneOrphanedQuaCache(): Promise<void> {
+	try {
+		const cacheDir = await getQuaCacheDir();
+		const referenced = await collectReferencedCacheFiles();
+		const cacheDirNorm = normalizeForCompare(cacheDir);
+
+		const slugDirs = await readDir(cacheDir);
+		for (const slugEntry of slugDirs) {
+			if (!slugEntry.isDirectory || !slugEntry.name) continue;
+			const slugDir = await join(cacheDir, slugEntry.name);
+			let remaining = 0;
+			const files = await readDir(slugDir);
+			for (const fileEntry of files) {
+				if (!fileEntry.isFile || !fileEntry.name) continue;
+				const abs = await join(slugDir, fileEntry.name);
+				const norm = normalizeForCompare(abs);
+				// Sécurité : ne touche qu'aux chemins réellement sous le cache.
+				if (!norm.startsWith(cacheDirNorm + '/')) continue;
+				if (referenced.has(norm)) {
+					remaining++;
+				} else {
+					await remove(abs);
+				}
+			}
+			// Supprime le sous-dossier du slug s'il ne reste aucun fichier référencé.
+			if (remaining === 0) {
+				try {
+					await remove(slugDir, { recursive: true });
+				} catch {
+					// Non bloquant : dossier non vide (autre contenu) ou déjà supprimé.
+				}
+			}
+		}
+	} catch (error) {
+		console.warn('QUA cache prune failed:', error);
+	}
+}

--- a/src/lib/services/UserAttentionService.ts
+++ b/src/lib/services/UserAttentionService.ts
@@ -129,17 +129,32 @@ async function showDesktopNotification(title: string, body: string): Promise<voi
  * @param {string} params.title Titre de la notification.
  * @param {string} params.body Message de détail.
  * @param {'success' | 'error'} params.level Niveau de résultat.
+ * @param {boolean} [params.skipWhenFocused] N'affiche pas la notification système si la
+ *   fenêtre est déjà au premier plan (l'utilisateur voit déjà le résultat à l'écran).
+ *   La demande d'attention fenêtre reste envoyée (no-op quand focus). Défaut : false.
  * @returns {Promise<void>} Promise résolue après les tentatives d'attention et de notification.
  */
 export async function notifyLongTaskCompletion(params: {
 	title: string;
 	body: string;
 	level: AttentionLevel;
+	skipWhenFocused?: boolean;
 }): Promise<void> {
 	if (typeof window === 'undefined') return;
 
+	// Notification redondante quand la fenêtre est déjà focus : l'utilisateur voit le
+	// résultat en direct. Opt-in par appelant pour ne pas changer les autres flux.
+	let showNotification = true;
+	if (params.skipWhenFocused) {
+		try {
+			showNotification = !(await getCurrentWindow().isFocused());
+		} catch {
+			showNotification = true;
+		}
+	}
+
 	await Promise.allSettled([
 		requestWindowAttention(params.level),
-		showDesktopNotification(params.title, params.body)
+		showNotification ? showDesktopNotification(params.title, params.body) : Promise.resolve()
 	]);
 }

--- a/src/lib/services/WbwHelper.ts
+++ b/src/lib/services/WbwHelper.ts
@@ -16,6 +16,28 @@ export type ManualWordByWordDraftWord = SegmentationWordTimestamp & {
 	word: string;
 };
 
+/**
+ * Marqueurs « lettre muette » (petit zéro rond, U+06DF/U+06E0) de l'orthographe
+ * Hafs/QPC, posés sur l'alif muet de la واو الجماعة (قالوا۟, ءامنوا۟…). Le script
+ * livré par la source QUA les inclut ; le jeu de données Quran de QC ne les met pas
+ * (il marque le silence via U+06E1). Ils s'affichent comme un petit cercle flottant
+ * au-dessus du mot dans les strips wbw miniatures.
+ */
+const WBW_DISPLAY_STRIP_MARKERS = /[۟۠]/g;
+
+/**
+ * Retire les marqueurs de lettre muette pour l'AFFICHAGE des strips wbw miniatures
+ * uniquement (le texte réel du mot reste intact partout ailleurs — sous-titre,
+ * export). Uniformise le rendu entre les clips issus de QUA et ceux des sources
+ * natives, qui n'embarquent pas ce glyphe.
+ *
+ * @param {string} text Texte arabe du mot.
+ * @returns {string} Texte sans le petit zéro rond.
+ */
+export function stripWbwDisplayMarkers(text: string): string {
+	return text.replace(WBW_DISPLAY_STRIP_MARKERS, '');
+}
+
 type SubtitlesEditorState = typeof globalState.getSubtitlesEditorState;
 export type SubtitlesEditorStateAccessor = () => SubtitlesEditorState;
 

--- a/src/lib/services/autoSegmentation/apply-segmentation.ts
+++ b/src/lib/services/autoSegmentation/apply-segmentation.ts
@@ -33,6 +33,17 @@ import { TrackType } from '$lib/classes/enums';
 import type { AssetTrack, SubtitleTrack } from '$lib/classes/Track.svelte';
 
 /**
+ * Rend la main au moteur de rendu toutes les {@link UI_YIELD_INTERVAL} itérations.
+ *
+ * Sur une longue sourate (Al-Baqara ≈ 286 versets → un millier de clips), la
+ * construction puis la matérialisation des clips tournent en une seule tâche
+ * synchrone : le navigateur ne peut jamais repeindre et l'app paraît figée.
+ * Un `setTimeout(0)` périodique laisse l'UI respirer sans changer la logique.
+ */
+const UI_YIELD_INTERVAL = 25;
+const yieldToUi = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
  * Marque les traductions d'un clip comme "to review".
  *
  * @param {SubtitleClip} clip Clip dont les traductions doivent être marquées.
@@ -559,6 +570,7 @@ export async function applySegmentationResponseToProject(
 
 	// Parcours des segments pour construire les templates
 	for (let segmentIndex = 0; segmentIndex < orderedSegments.length; segmentIndex += 1) {
+		if (segmentIndex > 0 && segmentIndex % UI_YIELD_INTERVAL === 0) await yieldToUi();
 		const segment = orderedSegments[segmentIndex];
 		if (segment.error) {
 			console.warn('Segment has error:', segment);
@@ -691,7 +703,9 @@ export async function applySegmentationResponseToProject(
 	}
 
 	// Matérialisation des templates
-	for (const template of clipTemplates) {
+	for (let templateIndex = 0; templateIndex < clipTemplates.length; templateIndex += 1) {
+		if (templateIndex > 0 && templateIndex % UI_YIELD_INTERVAL === 0) await yieldToUi();
+		const template = clipTemplates[templateIndex];
 		await materializeTemplate(
 			project,
 			subtitleTrack,
@@ -733,12 +747,14 @@ export async function applySegmentationResponseToProject(
 	}
 	subtitleTrack.clips.sort((a, b) => a.startTime - b.startTime);
 
-	// Mise à jour des timestamps dans les segments alignés
+	// Mise à jour des timestamps dans les segments alignés.
+	// Index clip-par-id construit une seule fois : `getClipById` fait un scan
+	// linéaire, donc le rappeler par segment donnait un coût O(n²) qui bloquait
+	// le thread après l'affichage des cartes sur une longue sourate.
+	const clipsById = new Map<number, (typeof subtitleTrack.clips)[number]>();
+	for (const clip of subtitleTrack.clips) clipsById.set(clip.id, clip);
 	for (const storedAlignedSegment of storedAlignedSegments) {
-		const clip = subtitleTrack.getClipById(storedAlignedSegment.clipId) as
-			| SubtitleClip
-			| PredefinedSubtitleClip
-			| null;
+		const clip = clipsById.get(storedAlignedSegment.clipId);
 		if (!clip) continue;
 		storedAlignedSegment.startMs = clip.startTime;
 		storedAlignedSegment.endMs = clip.endTime;

--- a/src/lib/services/autoSegmentation/apply-segmentation.ts
+++ b/src/lib/services/autoSegmentation/apply-segmentation.ts
@@ -147,7 +147,12 @@ async function materializeTemplate(
 	lowConfidenceSegments: { value: number },
 	coverageGapSegments: { value: number },
 	reviewSegments: { value: number },
-	storedAlignedSegments: StoredAlignedSegment[]
+	storedAlignedSegments: StoredAlignedSegment[],
+	// Tableau plat de destination (PAS `subtitleTrack.clips` réactif) : on pousse
+	// dans un array simple puis on l'assigne une seule fois côté appelant. Pousser
+	// 1300+ clips dans le $state proxy déclenche autant de re-renders timeline →
+	// c'était 95% du temps d'application.
+	targetClips: Array<SubtitleClip | PredefinedSubtitleClip>
 ): Promise<void> {
 	const alignmentSegment: SegmentationSegment = {
 		...template.segment,
@@ -165,7 +170,7 @@ async function materializeTemplate(
 			template.confidence,
 			project.content.projectTranslation
 		);
-		subtitleTrack.clips.push(clip);
+		targetClips.push(clip);
 		const storedAlignedSegment = buildStoredAlignedSegment(
 			clip.id,
 			'Pre-defined Subtitle',
@@ -257,7 +262,7 @@ async function materializeTemplate(
 		markClipTranslationsForReview(clip, project);
 	}
 
-	subtitleTrack.clips.push(clip);
+	targetClips.push(clip);
 	const storedAlignedSegment = buildStoredAlignedSegment(
 		clip.id,
 		'Subtitle',
@@ -702,7 +707,8 @@ export async function applySegmentationResponseToProject(
 		};
 	}
 
-	// Matérialisation des templates
+	// Matérialisation dans un tableau plat (non réactif) — voir materializeTemplate.
+	const builtClips: Array<SubtitleClip | PredefinedSubtitleClip> = [];
 	for (let templateIndex = 0; templateIndex < clipTemplates.length; templateIndex += 1) {
 		if (templateIndex > 0 && templateIndex % UI_YIELD_INTERVAL === 0) await yieldToUi();
 		const template = clipTemplates[templateIndex];
@@ -719,33 +725,32 @@ export async function applySegmentationResponseToProject(
 			lowConfidenceSegments,
 			{ value: coverageGapSegmentsNum },
 			reviewSegments,
-			storedAlignedSegments
+			storedAlignedSegments,
+			builtClips
 		);
 	}
+
 	// Récupération du compteur coverage gap
 	coverageGapSegmentsNum = storedAlignedSegments.length > 0 ? 0 : coverageGapSegmentsNum; // reset - sera recalculé
 
-	// Post-processing de la timeline
-	subtitleTrack.clips.sort((a, b) => a.startTime - b.startTime);
+	// Post-processing sur le tableau plat, puis UNE seule assignation réactive de
+	// `subtitleTrack.clips` : la timeline/preview ne se re-render qu'une fois au
+	// lieu d'une fois par clip.
+	builtClips.sort((a, b) => a.startTime - b.startTime);
+	closeSmallSubtitleGaps(builtClips);
 
-	const subtitleClips = subtitleTrack.clips.filter(
-		(clip) => clip.type === 'Subtitle' || clip.type === 'Pre-defined Subtitle'
-	) as Array<SubtitleClip | PredefinedSubtitleClip>;
-	closeSmallSubtitleGaps(subtitleClips);
-
+	let finalClips: Array<SubtitleClip | PredefinedSubtitleClip | SilenceClip>;
 	if (fillBySilence) {
-		subtitleTrack.clips = insertSilenceClips(subtitleClips);
+		finalClips = insertSilenceClips(builtClips);
 		if (extendBeforeSilence && extendBeforeSilenceMs > 0) {
-			extendSubtitlesBeforeSilence(
-				subtitleTrack.clips as Array<SubtitleClip | PredefinedSubtitleClip | SilenceClip>,
-				extendBeforeSilenceMs
-			);
+			extendSubtitlesBeforeSilence(finalClips, extendBeforeSilenceMs);
 		}
 	} else {
-		extendSubtitlesToFillGaps(subtitleClips);
-		subtitleTrack.clips = subtitleClips;
+		extendSubtitlesToFillGaps(builtClips);
+		finalClips = builtClips;
 	}
-	subtitleTrack.clips.sort((a, b) => a.startTime - b.startTime);
+	finalClips.sort((a, b) => a.startTime - b.startTime);
+	subtitleTrack.clips = finalClips;
 
 	// Mise à jour des timestamps dans les segments alignés.
 	// Index clip-par-id construit une seule fois : `getClipById` fait un scan

--- a/src/lib/services/autoSegmentation/run-preload.ts
+++ b/src/lib/services/autoSegmentation/run-preload.ts
@@ -25,16 +25,47 @@ import {
  * @param {Pick<AutoSegmentationOptions, 'fillBySilence' | 'extendBeforeSilence' | 'extendBeforeSilenceMs'>} options Options de post-processing.
  * @returns {Promise<AutoSegmentationResult | null>} Résumé du résultat ou null.
  */
+/** Options du flux Preload : options de segmentation + décalage temporel optionnel. */
+export type ApplyPreloadOptions = Pick<
+	AutoSegmentationOptions,
+	'fillBySilence' | 'extendBeforeSilence' | 'extendBeforeSilenceMs'
+> & {
+	/**
+	 * Décalage (ms) ajouté à TOUS les timestamps de segments/mots avant application.
+	 * Les timestamps Preload sont relatifs au début de la fenêtre de clip demandée
+	 * (0 = `start_ms`). Quand on télécharge une fenêtre audio qui commence plus tôt
+	 * (ex. depuis 0 pour garder l'isti'adha/basmala quand le verset 1 est inclus),
+	 * ce décalage (`start_ms − audioStart`) réaligne les sous-titres sur l'audio.
+	 */
+	timeOffsetMs?: number;
+};
+
+/** Décale (en place) tous les timestamps segment/mot de `offsetMs`. No-op si 0. */
+function shiftSegmentTimestamps(response: { segments?: unknown[] }, offsetMs: number): void {
+	if (!offsetMs) return;
+	const offsetS = offsetMs / 1000;
+	for (const segment of (response.segments ?? []) as Array<{
+		time_from?: number;
+		time_to?: number;
+		words?: Array<{ start?: number; end?: number }>;
+	}>) {
+		if (typeof segment.time_from === 'number') segment.time_from += offsetS;
+		if (typeof segment.time_to === 'number') segment.time_to += offsetS;
+		for (const word of segment.words ?? []) {
+			if (typeof word.start === 'number') word.start += offsetS;
+			if (typeof word.end === 'number') word.end += offsetS;
+		}
+	}
+}
+
 async function applyPreloadSegmentsToProjectCore(
 	payload: string | unknown,
-	options: Pick<
-		AutoSegmentationOptions,
-		'fillBySilence' | 'extendBeforeSilence' | 'extendBeforeSilenceMs'
-	> = {}
+	options: ApplyPreloadOptions = {}
 ): Promise<AutoSegmentationResult | null> {
 	const fillBySilence: boolean = options.fillBySilence ?? true;
 	const extendBeforeSilence: boolean = options.extendBeforeSilence ?? false;
 	const extendBeforeSilenceMs: number = options.extendBeforeSilenceMs ?? 0;
+	const timeOffsetMs: number = options.timeOffsetMs ?? 0;
 
 	const audioInfo = getAutoSegmentationAudioInfo();
 	const audioClips = getAutoSegmentationAudioClips();
@@ -56,6 +87,8 @@ async function applyPreloadSegmentsToProjectCore(
 
 	try {
 		const parsed = parseImportedSegmentationJson(payload);
+		// Réaligne les timestamps sur la fenêtre audio réellement téléchargée.
+		shiftSegmentTimestamps(parsed.response, timeOffsetMs);
 		return await applySegmentationResponseToProject({
 			response: parsed.response,
 			fillBySilence,
@@ -87,10 +120,7 @@ async function applyPreloadSegmentsToProjectCore(
  */
 export async function applyPreloadSegmentsToProject(
 	payload: string | unknown,
-	options: Pick<
-		AutoSegmentationOptions,
-		'fillBySilence' | 'extendBeforeSilence' | 'extendBeforeSilenceMs'
-	> = {}
+	options: ApplyPreloadOptions = {}
 ): Promise<AutoSegmentationResult | null> {
 	const release = AutoSegmentationExecutionCoordinator.tryAcquire('manual');
 	if (!release) return { status: 'failed', message: getAutoSegmentationBusyMessage() };

--- a/src/lib/services/autoSegmentation/run-preload.ts
+++ b/src/lib/services/autoSegmentation/run-preload.ts
@@ -40,21 +40,22 @@ export type ApplyPreloadOptions = Pick<
 	timeOffsetMs?: number;
 };
 
-/** Décale (en place) tous les timestamps segment/mot de `offsetMs`. No-op si 0. */
+/**
+ * Décale (en place) les bornes de segment `time_from`/`time_to` de `offsetMs`.
+ * No-op si 0. Les timestamps de MOTS ne sont PAS touchés : ils sont relatifs au
+ * début de leur segment (voir apply-segmentation `segmentStartMsRaw + word.start`),
+ * donc ils suivent automatiquement le segment décalé — les décaler aussi
+ * doublerait l'offset et les pousserait hors de leur clip.
+ */
 function shiftSegmentTimestamps(response: { segments?: unknown[] }, offsetMs: number): void {
 	if (!offsetMs) return;
 	const offsetS = offsetMs / 1000;
 	for (const segment of (response.segments ?? []) as Array<{
 		time_from?: number;
 		time_to?: number;
-		words?: Array<{ start?: number; end?: number }>;
 	}>) {
 		if (typeof segment.time_from === 'number') segment.time_from += offsetS;
 		if (typeof segment.time_to === 'number') segment.time_to += offsetS;
-		for (const word of segment.words ?? []) {
-			if (typeof word.start === 'number') word.start += offsetS;
-			if (typeof word.end === 'number') word.end += offsetS;
-		}
 	}
 }
 

--- a/tests/server/lib/services/BatchService.spec.ts
+++ b/tests/server/lib/services/BatchService.spec.ts
@@ -126,7 +126,7 @@ describe('BatchService persistence', () => {
 		await BatchService.delete(batch.id);
 
 		expect(deleteProject).toHaveBeenCalledOnce();
-		expect(deleteProject).toHaveBeenCalledWith(456);
+		expect(deleteProject).toHaveBeenCalledWith(456, { sweepQuaCache: false });
 		expect(storage.has(`/app-data/batches/${batch.id}.json`)).toBe(false);
 	});
 
@@ -194,7 +194,7 @@ describe('BatchService persistence', () => {
 
 		await BatchService.deleteProjects(batch, [20]);
 
-		expect(deleteProject).toHaveBeenCalledWith(20);
+		expect(deleteProject).toHaveBeenCalledWith(20, { sweepQuaCache: false });
 		expect(
 			(await BatchService.load(batch.id)).projects.map((project) => project.projectId)
 		).toEqual([10]);


### PR DESCRIPTION
Fixes recitation downloads failing on large surahs and overhauls the preload/download path end to end.

- **Download reliability** — replaces the 15-minute total-request timeout with a 120s idle read-timeout and falls back to a full GET when a resumed Range request is rejected, so multi-hour Mujawwad recitations download instead of erroring with `400 Bad Request`.
- **Download progress** — streams byte progress from Rust and shows it in a stable in-button progress bar instead of a generic spinner.
- **Runs across tab/window switches** — download state lives in a module-level store instead of the panel component, so switching editor tabs, switching projects, or unfocusing the window no longer interrupts an in-flight download or loses its progress; the target project is captured at launch so the asset always lands in the right project.
- **Completion notification** — on finish, fires a desktop notification (same pattern as export/segmentation) with the downloaded size, replacing the progress toast. The notification is skipped when the app window is already focused (the result is visible on screen); this skip-when-focused behavior is opt-in and does not change export, segmentation, or AI-trimming notifications.
- **Apply speed** — materializes segmented clips in a plain array and assigns the reactive track once, cutting a ~30s freeze on a full Al-Baqarah apply to well under a second (shared core, so auto-segmentation and JSON import benefit too).
- **Faithful intro/outro** — widens the downloaded audio window to the surah's natural boundaries when the selection touches them (keeps the isti'adha/basmala before verse 1, and the closing after the last verse), and re-aligns the preload word-by-word timestamps onto that window; mid-surah selections are unchanged.
- **Shared audio cache** — caches Quranic Universal Audio downloads in `qua-audio-cache/`, keyed by reciter slug + surah + verse range, and points each project's asset at the cache file: identical selections reuse it with zero re-download and zero per-project copy, and cache files are pruned once no live project references them.