### PR TITLE
fix(tauri): allow multiple Quran Caption windows

### DIFF
--- a/src-tauri/src/app/invoke.rs
+++ b/src-tauri/src/app/invoke.rs
@@ -24,6 +24,7 @@ pub fn register_invoke_handler(builder: tauri::Builder<tauri::Wry>) -> tauri::Bu
         commands::files::move_file,
         commands::files::send_http_get,
         commands::files::send_http_text,
+        commands::export_persistence::merge_export_entries,
         commands::media::get_system_fonts,
         commands::media::get_system_font_sources,
         commands::media::open_directory,

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,13 +1,53 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use tauri::Manager;
 
 use crate::binaries;
 
 mod invoke;
 
+static NEXT_WINDOW_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Indique si le second lancement correspond à un deep link Quran Caption.
+fn is_deep_link_launch(argv: &[String]) -> bool {
+    argv.iter()
+        .any(|arg| arg.to_ascii_lowercase().starts_with("qurancaption://"))
+}
+
+/// Ouvre une nouvelle fenêtre principale en réutilisant la configuration Tauri existante.
+fn open_additional_window(app: &tauri::AppHandle) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let Some(base_config) = app.config().app.windows.first() else {
+            return;
+        };
+        let mut config = base_config.clone();
+        config.label = format!(
+            "main{}",
+            NEXT_WINDOW_ID.fetch_add(1, Ordering::Relaxed)
+        );
+
+        if let Ok(builder) = tauri::WebviewWindowBuilder::from_config(&app, &config) {
+            let _ = builder.build();
+        }
+    });
+}
+
 /// Construit et lance l'application Tauri avec plugins, setup et commandes IPC.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let builder = tauri::Builder::default()
+    let builder = tauri::Builder::default();
+    let builder = if cfg!(debug_assertions) {
+        builder
+    } else {
+        builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            // Le plugin deep-link traite déjà le callback avant cette closure.
+            if !is_deep_link_launch(&argv) {
+                open_additional_window(app);
+            }
+        }))
+    };
+    let builder = builder
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_store::Builder::new().build())
@@ -15,17 +55,6 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init());
-    let builder = if cfg!(debug_assertions) {
-        builder
-    } else {
-        builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.unminimize();
-                let _ = window.set_focus();
-            }
-        }))
-    };
     let builder = invoke::register_invoke_handler(builder);
 
     builder

--- a/src-tauri/src/commands/export_persistence.rs
+++ b/src-tauri/src/commands/export_persistence.rs
@@ -1,0 +1,54 @@
+use std::collections::HashSet;
+use std::fs;
+use std::sync::{Mutex, OnceLock};
+
+use serde_json::Value;
+use tauri::Manager;
+
+static EXPORTS_FILE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Fusionne uniquement les exports appartenant à la fenêtre appelante dans `exports.json`.
+///
+/// @param app_handle Gestionnaire Tauri utilisé pour résoudre le dossier AppData.
+/// @param owned_export_ids Identifiants que la fenêtre appelante est autorisée à remplacer ou supprimer.
+/// @param exports Exports courants appartenant à la fenêtre appelante.
+/// @returns Succès lorsque la fusion atomique en mémoire puis l'écriture sur disque sont terminées.
+#[tauri::command]
+pub fn merge_export_entries(
+    app_handle: tauri::AppHandle,
+    owned_export_ids: Vec<i64>,
+    exports: Vec<Value>,
+) -> Result<(), String> {
+    let lock = EXPORTS_FILE_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock
+        .lock()
+        .map_err(|_| "Failed to lock export persistence".to_string())?;
+
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|error| error.to_string())?;
+    fs::create_dir_all(&app_data_dir).map_err(|error| error.to_string())?;
+    let file_path = app_data_dir.join("exports.json");
+
+    let mut existing = if file_path.exists() {
+        let content = fs::read_to_string(&file_path).map_err(|error| error.to_string())?;
+        serde_json::from_str::<Vec<Value>>(&content).map_err(|error| error.to_string())?
+    } else {
+        Vec::new()
+    };
+
+    let owned_ids = owned_export_ids.into_iter().collect::<HashSet<_>>();
+    existing.retain(|entry| {
+        entry
+            .get("exportId")
+            .and_then(Value::as_i64)
+            .map(|id| !owned_ids.contains(&id))
+            .unwrap_or(true)
+    });
+
+    let mut merged = exports;
+    merged.extend(existing);
+    let content = serde_json::to_string_pretty(&merged).map_err(|error| error.to_string())?;
+    fs::write(file_path, content).map_err(|error| error.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,6 +8,8 @@ pub mod diagnostics;
 pub mod discord;
 /// Commandes de téléchargement externes.
 pub mod downloads;
+/// Commandes de persistance du moniteur d'exports.
+pub mod export_persistence;
 /// Commandes de gestion de fichiers.
 pub mod files;
 /// Commandes multimédia et utilitaires ffmpeg/ffprobe.

--- a/src/lib/services/ExportService.ts
+++ b/src/lib/services/ExportService.ts
@@ -1,6 +1,8 @@
 import { SubtitleClip, TrackType, VerseRange, type Project } from '$lib/classes';
 import { exists, readTextFile, remove, writeTextFile } from '@tauri-apps/plugin-fs';
 import { appDataDir, join } from '@tauri-apps/api/path';
+import { invoke } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { globalState } from '$lib/runes/main.svelte';
 import Exportation, {
 	ExportKind,
@@ -33,6 +35,8 @@ export interface AddExportOptions {
 
 export default class ExportService {
 	static exportFolder: string = 'exports/';
+	private static loadedExportIds = new Set<number>();
+	private static ownedExportIds = new Set<number>();
 
 	constructor() {}
 
@@ -159,6 +163,7 @@ export default class ExportService {
 			is_batch_export: Boolean(options.exportLabel)
 		});
 
+		this.ownedExportIds.add(exportation.exportId);
 		globalState.exportations.unshift(exportation);
 
 		// Sauvegarde les exports en cours
@@ -204,31 +209,43 @@ export default class ExportService {
 	}
 
 	/**
-	 * Sauvegarde les exports en cours.
+	 * Sauvegarde uniquement les entrées modifiées par cette fenêtre sans écraser celles des autres.
+	 * @returns {Promise<void>} Promesse résolue après la fusion côté Rust.
 	 */
-	static async saveExports() {
-		// S'assure que le dossier existe
+	static async saveExports(): Promise<void> {
 		await ProjectService.ensureFolder(this.exportFolder);
 
-		// Construis le chemin d'accès vers le fichier contenant tout les exports
-		const filePath = await join(await appDataDir(), `exports.json`);
+		const currentIds = new Set(globalState.exportations.map((exp) => exp.exportId));
+		const changedExportIds = new Set(this.ownedExportIds);
 
-		await writeTextFile(
-			filePath,
-			JSON.stringify(
-				globalState.exportations.map((exp) => exp.toJSON()),
-				null,
-				2
-			)
-		);
+		for (const exportId of currentIds) {
+			if (!this.loadedExportIds.has(exportId)) changedExportIds.add(exportId);
+		}
+		for (const exportId of this.loadedExportIds) {
+			if (!currentIds.has(exportId)) changedExportIds.add(exportId);
+		}
+
+		if (changedExportIds.size === 0) return;
+
+		await invoke('merge_export_entries', {
+			ownedExportIds: Array.from(changedExportIds),
+			exports: globalState.exportations
+				.filter((exp) => changedExportIds.has(exp.exportId))
+				.map((exp) => exp.toJSON())
+		});
 	}
 
-	static async loadExports() {
+	/**
+	 * Charge le monitor d'exports sans annuler les exports appartenant à une autre fenêtre active.
+	 * @returns {Promise<void>} Promesse résolue lorsque l'état local est hydraté.
+	 */
+	static async loadExports(): Promise<void> {
 		const filePath = await join(await appDataDir(), `exports.json`);
 
 		if ((await exists(filePath)) === false) {
 			// Aucun export trouvé
 			globalState.exportations = [];
+			this.loadedExportIds = new Set();
 			return;
 		}
 
@@ -238,13 +255,28 @@ export default class ExportService {
 		globalState.exportations = data.map(
 			(exp) => Exportation.fromJSON(exp as Record<string, unknown>) as Exportation
 		);
+		this.loadedExportIds = new Set(globalState.exportations.map((exp) => exp.exportId));
 
-		// Tout les exports en cours on les mets en canceled
+		// Seule la fenêtre initiale correspond à un vrai redémarrage du processus.
+		if (getCurrentWindow().label !== 'main') return;
+
+		const interruptedExportIds: number[] = [];
 		globalState.exportations.forEach((exp) => {
 			if (exp.isOnGoing()) {
 				exp.currentState = ExportState.Canceled;
+				interruptedExportIds.push(exp.exportId);
 			}
 		});
+
+		if (interruptedExportIds.length > 0) {
+			const interruptedIds = new Set(interruptedExportIds);
+			await invoke('merge_export_entries', {
+				ownedExportIds: interruptedExportIds,
+				exports: globalState.exportations
+					.filter((exp) => interruptedIds.has(exp.exportId))
+					.map((exp) => exp.toJSON())
+			});
+		}
 	}
 
 	static async deleteProjectFile(exportIdId: number) {

--- a/src/lib/services/ExportService.ts
+++ b/src/lib/services/ExportService.ts
@@ -302,7 +302,9 @@ export default class ExportService {
 	}
 
 	static currentlyExportingProjects() {
-		return globalState.exportations.filter((exp) => exp.isOnGoing());
+		return globalState.exportations.filter(
+			(exp) => exp.isOnGoing() && this.ownedExportIds.has(exp.exportId)
+		);
 	}
 }
 

--- a/src/lib/services/QuranAuthService.svelte.ts
+++ b/src/lib/services/QuranAuthService.svelte.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import { invoke } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import toast from 'svelte-5-french-toast';
@@ -18,6 +19,7 @@ const USER_API_BASE_URL = 'https://apis.quran.foundation';
 // const BRIDGE_BASE_URL = 'http://localhost:5174';
 const SESSION_STORAGE_KEY = 'quran_auth_session';
 const PENDING_VERIFIER_STORAGE_KEY = 'quran_auth_pending_verifier';
+const PENDING_WINDOW_STORAGE_KEY = 'quran_auth_pending_window';
 const REFRESH_SKEW_MS = 60_000;
 const QURAN_MUSHAF_ID = 4;
 
@@ -116,7 +118,10 @@ class QuranAuthService {
 			this.handledHandoffTokens.clear();
 
 			const { verifier, challenge } = await generatePkcePair();
-			await this.setSecureValue(PENDING_VERIFIER_STORAGE_KEY, verifier);
+			await Promise.all([
+				this.setSecureValue(PENDING_VERIFIER_STORAGE_KEY, verifier),
+				this.setSecureValue(PENDING_WINDOW_STORAGE_KEY, getCurrentWindow().label)
+			]);
 
 			const authorizationUrl = new URL('/oauth/quran/start', BRIDGE_BASE_URL);
 			authorizationUrl.searchParams.set('handoff_challenge', challenge);
@@ -148,6 +153,15 @@ class QuranAuthService {
 	async handleDeepLink(url: string): Promise<void> {
 		const parsedUrl = new URL(url);
 		if (!isQuranAuthCallbackUrl(parsedUrl)) return;
+
+		const currentWindowLabel = getCurrentWindow().label;
+		const pendingWindowLabel = await this.getSecureValue(PENDING_WINDOW_STORAGE_KEY);
+		if (
+			(pendingWindowLabel && pendingWindowLabel !== currentWindowLabel) ||
+			(!pendingWindowLabel && currentWindowLabel !== 'main')
+		) {
+			return;
+		}
 
 		const handoffToken = parsedUrl.searchParams.get('handoff_token');
 		if (!handoffToken) {
@@ -237,10 +251,7 @@ class QuranAuthService {
 		this.activeHandoffToken = null;
 		this.handledHandoffTokens.clear();
 
-		await Promise.all([
-			this.deleteSecureValue(SESSION_STORAGE_KEY),
-			this.deleteSecureValue(PENDING_VERIFIER_STORAGE_KEY)
-		]);
+		await Promise.all([this.deleteSecureValue(SESSION_STORAGE_KEY), this.clearPendingVerifier()]);
 		if (wasConnected) {
 			AnalyticsService.trackQuranAuthDisconnected(scopeCount, reason);
 		}
@@ -460,9 +471,12 @@ class QuranAuthService {
 		await this.setSecureValue(SESSION_STORAGE_KEY, JSON.stringify(persistedSession));
 	}
 
-	/** Supprime le verifier PKCE temporaire après succès ou annulation. */
+	/** Supprime le contexte PKCE temporaire après succès ou annulation. */
 	private async clearPendingVerifier(): Promise<void> {
-		await this.deleteSecureValue(PENDING_VERIFIER_STORAGE_KEY);
+		await Promise.all([
+			this.deleteSecureValue(PENDING_VERIFIER_STORAGE_KEY),
+			this.deleteSecureValue(PENDING_WINDOW_STORAGE_KEY)
+		]);
 	}
 
 	/**


### PR DESCRIPTION
## What does this PR do?

- Keeps a single Tauri process so Windows/Linux deep links continue to be forwarded correctly.
- Opens a new independent Quran Caption main window for every normal secondary app launch instead of focusing the existing `main` window.
- Routes Quran.com OAuth callbacks only to the window that initiated the PKCE flow.
- Makes `exports.json` persistence safer across windows by merging only entries owned/changed by the current window under a Rust-side lock.
- Prevents additional windows from marking already-running exports as canceled when they load the export monitor.
- Makes window-close cleanup ownership-aware, so closing one Quran Caption window only considers and cancels exports started from that window.

## Why is this change needed?

Quran Caption currently prevents users from opening more than one desktop workspace at the same time. Users should be able to open several projects side by side without a secondary window canceling exports started from another window.

## Testing / safeguards

- The branch was intentionally restored to commit `794382e880a408b1c2eb0ef43603a5adeb826da7` as the implementation baseline.
- All later multi-window export synchronization and global queue changes were removed.
- One additional fix is applied on top: `currentlyExportingProjects()` now returns only exports owned by the current window, preventing another window's exports from being canceled during close cleanup.